### PR TITLE
feat: add configurable timeout for backendEndpoint calls

### DIFF
--- a/api/src/main/proto/eds-v1.proto
+++ b/api/src/main/proto/eds-v1.proto
@@ -42,6 +42,7 @@ message Configuration {
   optional string apiKey = 6;
   optional OAuth2Configuration oauth2Configuration = 7;
   optional Secret backendSecret = 8;
+  optional int64 backendEndpointTimeout = 9;  // For backendEndpoint Timeout
 }
 
 message OAuth2Configuration {

--- a/control-plane/src/main/java/io/reshapr/ctrl/model/ConfigurationPlan.java
+++ b/control-plane/src/main/java/io/reshapr/ctrl/model/ConfigurationPlan.java
@@ -48,6 +48,9 @@ public class ConfigurationPlan extends TenantAwareEntity {
    @Column(name = "backend_endpoint", nullable = false)
    public String backendEndpoint;
 
+   @Column(name = "backend_endpoint_timeout")
+   public Long backendEndpointTimeout;
+
    @Type(JsonType.class)
    @Column(columnDefinition = "JSONB", name = "excluded_operations")
    public List<String> excludedOperations;

--- a/control-plane/src/main/java/io/reshapr/ctrl/rest/v1/ConfigurationPlanDTO.java
+++ b/control-plane/src/main/java/io/reshapr/ctrl/rest/v1/ConfigurationPlanDTO.java
@@ -40,6 +40,7 @@ public class ConfigurationPlanDTO {
    protected String description;
    protected String serviceId;
    protected String backendEndpoint;
+   protected Long backendEndpointTimeout;
    protected List<String> excludedOperations;
    protected List<String> includedOperations;
    protected String backendSecretId;
@@ -142,5 +143,13 @@ public class ConfigurationPlanDTO {
 
    public void setInitialAccessToken(String initialAccessToken) {
       this.initialAccessToken = initialAccessToken;
+   }
+
+   public Long getBackendEndpointTimeout() {
+      return backendEndpointTimeout;
+   }
+
+   public void setBackendEndpointTimeout(Long backendEndpointTimeout) {
+      this.backendEndpointTimeout = backendEndpointTimeout;
    }
 }

--- a/control-plane/src/main/java/io/reshapr/ctrl/service/ConfigurationPlanManagerService.java
+++ b/control-plane/src/main/java/io/reshapr/ctrl/service/ConfigurationPlanManagerService.java
@@ -148,6 +148,7 @@ public class ConfigurationPlanManagerService {
       existingPlan.name = configurationPlan.name;
       existingPlan.description = configurationPlan.description;
       existingPlan.backendEndpoint = configurationPlan.backendEndpoint;
+      existingPlan.backendEndpointTimeout = configurationPlan.backendEndpointTimeout;
       existingPlan.includedOperations = configurationPlan.includedOperations;
       existingPlan.excludedOperations = configurationPlan.excludedOperations;
       if (backendSecretId != null) {

--- a/control-plane/src/main/java/io/reshapr/ctrl/service/ExpositionDiscoveryServiceHandler.java
+++ b/control-plane/src/main/java/io/reshapr/ctrl/service/ExpositionDiscoveryServiceHandler.java
@@ -335,6 +335,7 @@ public class ExpositionDiscoveryServiceHandler extends ExpositionDiscoveryServic
             .setId(configuration.id)
             .setName(configuration.name)
             .setBackendEndpoint(configuration.backendEndpoint)
+            .setBackendEndpointTimeout(configuration.backendEndpointTimeout != null ? configuration.backendEndpointTimeout : 3_000L)
             .addAllExcludedOperations(configuration.excludedOperations != null ? configuration.excludedOperations : List.of())
             .addAllIncludedOperations(configuration.includedOperations != null ? configuration.includedOperations : List.of());
 

--- a/control-plane/src/main/resources/db/migration/V1.0.1__add_backend_endpoint_timeout.sql
+++ b/control-plane/src/main/resources/db/migration/V1.0.1__add_backend_endpoint_timeout.sql
@@ -1,0 +1,2 @@
+ALTER TABLE configuration_plans
+    ADD COLUMN backend_endpoint_timeout BIGINT;

--- a/proxy/src/main/java/io/reshapr/proxy/proxy/ProxyService.java
+++ b/proxy/src/main/java/io/reshapr/proxy/proxy/ProxyService.java
@@ -67,8 +67,11 @@ public class ProxyService {
     * @return A BackendResponse containing the status code, body, and headers from the backend response.
     */
    public BackendResponse callBackend(ConfigurationEntry configuration, URI externalUrl, String method, Map<String, List<String>> headers, String body) {
+      long timeoutMs = configuration.backendEndpointTimeout() != null ? configuration.backendEndpointTimeout() : 3_000L;
+
       HttpRequest.Builder requestBuilder = HttpRequest.newBuilder()
             .uri(externalUrl)
+            .timeout(Duration.ofMillis(timeoutMs))
             .method(method, body == null ? HttpRequest.BodyPublishers.noBody() : HttpRequest.BodyPublishers.ofString(body));
 
       // Some headers are restricted in HttpClient and must not be propagated.
@@ -115,8 +118,8 @@ public class ProxyService {
          // Return the response as is.
          return new BackendResponse(response.statusCode(), response.body(), response.headers().map());
       } catch (HttpTimeoutException e) {
-         logger.errorf("Proxy timeout calling backend '%s': %s", externalUrl, e.getMessage());
-         return new BackendResponse(504, "Gateway Timeout: backend did not respond in time".getBytes(StandardCharsets.UTF_8), Map.of());
+         logger.errorf("Proxy timed out after %dms calling: '%s'", timeoutMs, externalUrl);
+         return new BackendResponse(504, ("Backend timed out after " + timeoutMs + "ms").getBytes(StandardCharsets.UTF_8), Map.of());
       } catch (ConnectException e) {
          logger.errorf("Proxy connection refused by backend '%s': %s", externalUrl, e.getMessage());
          return new BackendResponse(503, "Service Unavailable: backend refused the connection".getBytes(StandardCharsets.UTF_8), Map.of());

--- a/proxy/src/main/java/io/reshapr/proxy/registry/ConfigurationEntry.java
+++ b/proxy/src/main/java/io/reshapr/proxy/registry/ConfigurationEntry.java
@@ -25,6 +25,7 @@ public record ConfigurationEntry(
       String id,
       String name,
       String backendEndpoint,
+      Long backendEndpointTimeout,
       List<String> excludedOperations,
       List<String> includedOperations,
       String apiKey,

--- a/proxy/src/main/java/io/reshapr/proxy/registry/Mappers.java
+++ b/proxy/src/main/java/io/reshapr/proxy/registry/Mappers.java
@@ -42,6 +42,7 @@ public interface Mappers {
 
    @Mapping(target = "excludedOperations", source = "excludedOperationsList")
    @Mapping(target = "includedOperations", source = "includedOperationsList")
+   @Mapping(target = "backendEndpointTimeout", expression = "java(configuration.hasBackendEndpointTimeout() ? configuration.getBackendEndpointTimeout() : null)")
    public ConfigurationEntry toConfigurationEntry(Configuration configuration);
 
    @Mapping(target = "authorizationServers", source = "authorizationServersList")

--- a/proxy/src/test/java/io/reshapr/proxy/proxy/ProxyServiceTest.java
+++ b/proxy/src/test/java/io/reshapr/proxy/proxy/ProxyServiceTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright The Reshapr Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.reshapr.proxy.proxy;
+
+import io.reshapr.proxy.registry.ConfigurationEntry;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class ProxyServiceTest {
+
+   @Test
+   void shouldThrowHttpTimeoutExceptionWhenRequestTimeoutExpires() throws Exception {
+      HttpClient client = HttpClient.newBuilder()
+            .connectTimeout(Duration.ofMillis(300))
+            .version(HttpClient.Version.HTTP_1_1)
+            .build();
+
+      HttpRequest request = HttpRequest.newBuilder()
+            .uri(URI.create("http://10.255.255.1/api"))
+            .timeout(Duration.ofMillis(300))
+            .GET()
+            .build();
+
+      assertThrows(java.net.http.HttpTimeoutException.class,
+            () -> client.send(request, HttpResponse.BodyHandlers.ofByteArray()));
+   }
+
+   @Test
+   void configurationEntryHoldsTimeoutValue() {
+      ConfigurationEntry config = new ConfigurationEntry(
+            "id", "test", "http://example.com",
+            5_000L, List.of(), List.of(), null, null, null);
+
+      assertEquals(5_000L, config.backendEndpointTimeout());
+   }
+
+   @Test
+   void defaultFallbackIs3000ms() {
+      ConfigurationEntry config = new ConfigurationEntry(
+            "id", "test", "http://example.com",
+            null, List.of(), List.of(), null, null, null);
+
+      long timeoutMs = config.backendEndpointTimeout() != null
+            ? config.backendEndpointTimeout()
+            : 3_000L;
+
+      assertEquals(3_000L, timeoutMs);
+   }
+}


### PR DESCRIPTION
Closes #15

Add a `backendEndpointTimeout` field (ms) to `ConfigurationPlan`. When importing an API, 
set it via the control plane API. Defaults to 3000ms if not set. Proxy now returns 
HTTP 504 instead of hanging indefinitely when the backend does not respond in time.

Tested via `ProxyServiceTest` - all 3 tests pass.