### PR TITLE
fix: #67 Differentiate backend error types in ProxyService exception handling

### DIFF
--- a/proxy/src/main/java/io/reshapr/proxy/proxy/ProxyService.java
+++ b/proxy/src/main/java/io/reshapr/proxy/proxy/ProxyService.java
@@ -28,10 +28,12 @@ import jakarta.ws.rs.core.HttpHeaders;
 import org.jboss.logging.Logger;
 
 import java.io.IOException;
+import java.net.ConnectException;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.net.http.HttpTimeoutException;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.Base64;
@@ -109,9 +111,23 @@ public class ProxyService {
 
          // Return the response as is.
          return new BackendResponse(response.statusCode(), response.body(), response.headers().map());
+      } catch (HttpTimeoutException e) {
+         logger.errorf("Proxy timeout calling backend '%s': %s", externalUrl, e.getMessage());
+         return new BackendResponse(504, "Gateway Timeout: backend did not respond in time".getBytes(StandardCharsets.UTF_8), Map.of());
+      } catch (ConnectException e) {
+         logger.errorf("Proxy connection refused by backend '%s': %s", externalUrl, e.getMessage());
+         return new BackendResponse(503, "Service Unavailable: backend refused the connection".getBytes(StandardCharsets.UTF_8), Map.of());
+      } catch (IOException e) {
+         logger.errorf("Proxy I/O error calling backend '%s': %s", externalUrl, e.getMessage());
+         return new BackendResponse(502, "Bad Gateway: unexpected network error".getBytes(StandardCharsets.UTF_8), Map.of());
+      } catch (InterruptedException e) {
+         Thread.currentThread().interrupt();
+         logger.errorf("Proxy call to backend '%s' was interrupted", externalUrl);
+         return new BackendResponse(500, "Internal Server Error: request was interrupted".getBytes(StandardCharsets.UTF_8), Map.of());
       } catch (Exception e) {
-         logger.errorf("Proxy raised: '%s'", e.getMessage());
-         return new BackendResponse(500, e.getMessage().getBytes(StandardCharsets.UTF_8), Map.of());
+         String message = e.getMessage() != null ? e.getMessage() : "Unknown error";
+         logger.errorf("Proxy raised unexpected error calling backend '%s': %s", externalUrl, message);
+         return new BackendResponse(500, ("Internal Server Error: " + message).getBytes(StandardCharsets.UTF_8), Map.of());
       }
    }
 


### PR DESCRIPTION
## Summary

- Replace the catch-all `Exception` block in `ProxyService.callBackend()` with specific exception handlers that return semantically correct HTTP status codes
- Null-guard `e.getMessage()` to prevent NPE on exceptions with null messages
- Restore the interrupt flag on `InterruptedException` per Java best practices

Closes #67

## Changes

| Exception | Status | Meaning |
|-----------|--------|---------|
| `HttpTimeoutException` | **504** Gateway Timeout | Backend did not respond in time |
| `ConnectException` | **503** Service Unavailable | Backend refused the connection |
| `IOException` (other) | **502** Bad Gateway | Unexpected network or protocol error |
| `InterruptedException` | **500** Internal Server Error | Thread was interrupted |
| `Exception` (fallback) | **500** Internal Server Error | Unexpected failure (with null-safe message) |

Log messages now also include the backend URL for easier diagnosis.

## Test plan

- [ ] Verify `mvn -B clean install` passes
- [ ] Manual test: point a gateway at an unreachable backend → expect 503
- [ ] Manual test: point a gateway at a slow backend exceeding connect timeout → expect 504
- [ ] Manual test: point a gateway at a backend that drops the connection mid-response → expect 502