### PR TITLE
fix: #71 Differentiate gRPC backend error types in GrpcProxyService exception handling

### DIFF
--- a/proxy/src/main/java/io/reshapr/proxy/proxy/GrpcProxyService.java
+++ b/proxy/src/main/java/io/reshapr/proxy/proxy/GrpcProxyService.java
@@ -127,8 +127,9 @@ public class GrpcProxyService {
       try {
          parser.merge(body, reqBuilder);
       } catch (InvalidProtocolBufferException e) {
-         logger.errorf("Exception while parsing JSON to Protobuf: '%s'", e.getMessage());
-         return new BackendResponse(400, e.getMessage().getBytes(StandardCharsets.UTF_8), Map.of());
+         String message = e.getMessage() != null ? e.getMessage() : "Invalid JSON to Protobuf conversion";
+         logger.errorf("Exception while parsing JSON to Protobuf: '%s'", message);
+         return new BackendResponse(400, message.getBytes(StandardCharsets.UTF_8), Map.of());
       }
       byte[] requestBytes = reqBuilder.build().toByteArray();
 
@@ -165,15 +166,19 @@ public class GrpcProxyService {
             JsonFormat.Printer printer = JsonFormat.printer();
             contentResponse = printer.print(respMsg);
          } catch (InvalidProtocolBufferException ipbe) {
-            logger.errorf("Exception while converting Protobuf to JSON: '%s'", ipbe.getMessage());
-            return new BackendResponse(400, ipbe.getMessage().getBytes(StandardCharsets.UTF_8), Map.of());
+            String message = ipbe.getMessage() != null ? ipbe.getMessage() : "Invalid Protobuf to JSON conversion";
+            logger.errorf("Exception while converting Protobuf to JSON: '%s'", message);
+            return new BackendResponse(400, message.getBytes(StandardCharsets.UTF_8), Map.of());
          }
 
          return new BackendResponse(Status.Code.OK.value(),
                contentResponse.getBytes(StandardCharsets.UTF_8), Map.of());
       } catch (StatusRuntimeException sre) {
-         logger.errorf(sre, "Proxy raised: '%s'", sre.getMessage());
-         return new BackendResponse(500, sre.getMessage().getBytes(StandardCharsets.UTF_8), Map.of());
+         int httpStatus = mapGrpcStatusToHttp(sre.getStatus().getCode());
+         String message = sre.getMessage() != null ? sre.getMessage() : sre.getStatus().getCode().name();
+         logger.errorf("gRPC proxy error calling backend '%s' [%s -> HTTP %d]: %s",
+               configuration.backendEndpoint(), sre.getStatus().getCode(), httpStatus, message);
+         return new BackendResponse(httpStatus, message.getBytes(StandardCharsets.UTF_8), Map.of());
       } finally {
          // Shutdown the channel to release resources.
          originChannel.shutdown();
@@ -185,6 +190,20 @@ public class GrpcProxyService {
                                   CallOptions callOptions, byte[] requestBytes,
                                   @SpanAttribute("backendEndpoint") String backendEndpoint) throws StatusRuntimeException {
       return ClientCalls.blockingUnaryCall(channel, unaryMethodDescriptor, callOptions, requestBytes);
+   }
+
+   private static int mapGrpcStatusToHttp(Status.Code code) {
+      return switch (code) {
+         case DEADLINE_EXCEEDED -> 504;
+         case UNAVAILABLE -> 503;
+         case UNAUTHENTICATED -> 401;
+         case PERMISSION_DENIED -> 403;
+         case NOT_FOUND -> 404;
+         case INVALID_ARGUMENT -> 400;
+         case UNIMPLEMENTED -> 501;
+         case RESOURCE_EXHAUSTED -> 429;
+         default -> 502;
+      };
    }
 
    private CallOptions manageSecurityHeaders(SecretEntry secret, CallOptions callOptions, Map<String, List<String>> headers) {


### PR DESCRIPTION
## Summary

- Map gRPC `Status.Code` to semantically correct HTTP status codes in `GrpcProxyService.callBackend()` instead of always returning 500
- Null-guard all `getMessage().getBytes()` calls to prevent NPE on exceptions with null messages
- Include the backend endpoint and gRPC status code in error log messages for easier diagnosis

Closes #71

## Changes

The `StatusRuntimeException` catch block now extracts the gRPC status code and maps it to the appropriate HTTP status:

| gRPC Status Code | HTTP Status | Meaning |
|---|---|---|
| `DEADLINE_EXCEEDED` | **504** Gateway Timeout | Backend did not respond within deadline |
| `UNAVAILABLE` | **503** Service Unavailable | Backend is not reachable |
| `UNAUTHENTICATED` | **401** Unauthorized | Missing or invalid credentials |
| `PERMISSION_DENIED` | **403** Forbidden | Caller lacks permission |
| `NOT_FOUND` | **404** Not Found | Resource or method not found |
| `INVALID_ARGUMENT` | **400** Bad Request | Invalid request parameters |
| `UNIMPLEMENTED` | **501** Not Implemented | Method not supported by backend |
| `RESOURCE_EXHAUSTED` | **429** Too Many Requests | Rate limited or quota exceeded |
| All others | **502** Bad Gateway | Generic upstream failure |

This is the gRPC counterpart of #67 / PR #70 which applied the same pattern to the HTTP `ProxyService`.

## Test plan

- [ ] Verify `mvn -B clean install` passes
- [ ] Manual test: set a gRPC backend deadline shorter than the call duration -> expect 504
- [ ] Manual test: point at a non-existent gRPC backend -> expect 503
- [ ] Manual test: call a gRPC backend that returns `PERMISSION_DENIED` -> expect 403