### PR TITLE
feat: Kubernetes admission controller story for Reshapr proxy as a sidecar container #123

### DIFF
--- a/control-plane/pom.xml
+++ b/control-plane/pom.xml
@@ -168,11 +168,7 @@
       <scope>provided</scope>
     </dependency>
 
-    <dependency>
-      <groupId>io.github.vishwakarma</groupId>
-      <artifactId>zjsonpatch</artifactId>
-      <version>0.6.2</version>
-    </dependency>
+
 
     <dependency>
       <groupId>io.quarkus</groupId>

--- a/control-plane/pom.xml
+++ b/control-plane/pom.xml
@@ -116,6 +116,11 @@
 
     <dependency>
       <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-kubernetes-client</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.quarkus</groupId>
       <artifactId>quarkus-smallrye-jwt</artifactId>
     </dependency>
     <dependency>
@@ -161,6 +166,12 @@
       <artifactId>bootstrap</artifactId>
       <version>5.3.8</version>
       <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>io.github.vishwakarma</groupId>
+      <artifactId>zjsonpatch</artifactId>
+      <version>0.6.2</version>
     </dependency>
 
     <dependency>

--- a/control-plane/src/main/java/io/reshapr/ctrl/webhook/MutatingWebhookResource.java
+++ b/control-plane/src/main/java/io/reshapr/ctrl/webhook/MutatingWebhookResource.java
@@ -1,0 +1,126 @@
+package io.reshapr.ctrl.webhook;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.ContainerBuilder;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.admission.v1.AdmissionRequest;
+import io.fabric8.kubernetes.api.model.admission.v1.AdmissionResponse;
+import io.fabric8.kubernetes.api.model.admission.v1.AdmissionResponseBuilder;
+import io.fabric8.kubernetes.api.model.admission.v1.AdmissionReview;
+import io.fabric8.kubernetes.api.model.admission.v1.AdmissionReviewBuilder;
+
+import io.github.vishwakarma.zjsonpatch.JsonDiff;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import org.jboss.logging.Logger;
+
+@Path("/api/v1/webhooks/mutate")
+@Consumes(MediaType.APPLICATION_JSON)
+@Produces(MediaType.APPLICATION_JSON)
+public class MutatingWebhookResource {
+
+    private static final Logger log = Logger.getLogger(MutatingWebhookResource.class);
+    private static final String INJECT_ANNOTATION = "io.reshapr/inject";
+    private static final String PROXY_IMAGE = "quay.io/reshapr/reshapr-proxy:latest";
+    private static final String PROXY_CONTAINER_NAME = "reshapr-proxy";
+
+    @Inject
+    ObjectMapper objectMapper;
+
+    @POST
+    public AdmissionReview mutate(AdmissionReview review) {
+        AdmissionRequest request = review.getRequest();
+        if (request == null) {
+            return review;
+        }
+
+        String uid = request.getUid();
+        
+        // We only care about Pods
+        if (!"Pod".equals(request.getKind().getKind())) {
+            return new AdmissionReviewBuilder()
+                    .withResponse(new AdmissionResponseBuilder()
+                            .withUid(uid)
+                            .withAllowed(true)
+                            .build())
+                    .build();
+        }
+
+        try {
+            Pod pod = objectMapper.convertValue(request.getObject(), Pod.class);
+            Map<String, String> annotations = pod.getMetadata().getAnnotations();
+            
+            if (annotations != null && "true".equalsIgnoreCase(annotations.get(INJECT_ANNOTATION))) {
+                log.infof("Injecting Reshapr proxy into pod %s", pod.getMetadata().getName());
+                
+                // Clone the pod for diffing
+                Pod mutatedPod = objectMapper.treeToValue(objectMapper.valueToTree(pod), Pod.class);
+                
+                // Check if container already exists
+                boolean alreadyInjected = mutatedPod.getSpec().getContainers().stream()
+                        .anyMatch(c -> PROXY_CONTAINER_NAME.equals(c.getName()));
+                        
+                if (!alreadyInjected) {
+                    Container proxyContainer = new ContainerBuilder()
+                            .withName(PROXY_CONTAINER_NAME)
+                            .withImage(PROXY_IMAGE)
+                            // Additional config such as env variables or ports can be added here
+                            .build();
+                            
+                    mutatedPod.getSpec().getContainers().add(proxyContainer);
+                    
+                    // Generate JSON patch
+                    String patch = generatePatch(pod, mutatedPod);
+                    
+                    return new AdmissionReviewBuilder()
+                            .withResponse(new AdmissionResponseBuilder()
+                                    .withUid(uid)
+                                    .withAllowed(true)
+                                    .withPatchType("JSONPatch")
+                                    .withPatch(Base64.getEncoder().encodeToString(patch.getBytes(StandardCharsets.UTF_8)))
+                                    .build())
+                            .build();
+                }
+            }
+            
+            // Allow without mutations
+            return new AdmissionReviewBuilder()
+                    .withResponse(new AdmissionResponseBuilder()
+                            .withUid(uid)
+                            .withAllowed(true)
+                            .build())
+                    .build();
+                    
+        } catch (Exception e) {
+            log.error("Failed to process admission request", e);
+            return new AdmissionReviewBuilder()
+                    .withResponse(new AdmissionResponseBuilder()
+                            .withUid(uid)
+                            .withAllowed(false)
+                            .withNewStatus()
+                                .withCode(500)
+                                .withMessage(e.getMessage())
+                            .endStatus()
+                            .build())
+                    .build();
+        }
+    }
+
+    private String generatePatch(Pod originalPod, Pod mutatedPod) throws JsonProcessingException {
+        var originalNode = objectMapper.valueToTree(originalPod);
+        var mutatedNode = objectMapper.valueToTree(mutatedPod);
+        var patchNode = JsonDiff.asJson(originalNode, mutatedNode);
+        return objectMapper.writeValueAsString(patchNode);
+    }
+}

--- a/control-plane/src/main/java/io/reshapr/ctrl/webhook/MutatingWebhookResource.java
+++ b/control-plane/src/main/java/io/reshapr/ctrl/webhook/MutatingWebhookResource.java
@@ -16,7 +16,7 @@ import io.fabric8.kubernetes.api.model.admission.v1.AdmissionResponseBuilder;
 import io.fabric8.kubernetes.api.model.admission.v1.AdmissionReview;
 import io.fabric8.kubernetes.api.model.admission.v1.AdmissionReviewBuilder;
 
-import io.github.vishwakarma.zjsonpatch.JsonDiff;
+import io.fabric8.zjsonpatch.JsonDiff;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.POST;
@@ -53,8 +53,7 @@ public class MutatingWebhookResource {
                     .withResponse(new AdmissionResponseBuilder()
                             .withUid(uid)
                             .withAllowed(true)
-                            .build())
-                    .build();
+                            .build()).build();
         }
 
         try {
@@ -108,19 +107,19 @@ public class MutatingWebhookResource {
                     .withResponse(new AdmissionResponseBuilder()
                             .withUid(uid)
                             .withAllowed(false)
-                            .withNewStatus()
+                            .withStatus(new io.fabric8.kubernetes.api.model.StatusBuilder()
                                 .withCode(500)
                                 .withMessage(e.getMessage())
-                            .endStatus()
+                                .build())
                             .build())
                     .build();
         }
     }
 
-    private String generatePatch(Pod originalPod, Pod mutatedPod) throws JsonProcessingException {
-        var originalNode = objectMapper.valueToTree(originalPod);
-        var mutatedNode = objectMapper.valueToTree(mutatedPod);
-        var patchNode = JsonDiff.asJson(originalNode, mutatedNode);
-        return objectMapper.writeValueAsString(patchNode);
-    }
+private String generatePatch(Pod originalPod, Pod mutatedPod) throws JsonProcessingException {
+    var originalNode = objectMapper.valueToTree(originalPod);
+    var mutatedNode = objectMapper.valueToTree(mutatedPod);
+    var patchNode = JsonDiff.asJson(originalNode, mutatedNode);
+    return objectMapper.writeValueAsString(patchNode);
+}
 }

--- a/control-plane/src/test/java/io/reshapr/ctrl/webhook/MutatingWebhookResourceTest.java
+++ b/control-plane/src/test/java/io/reshapr/ctrl/webhook/MutatingWebhookResourceTest.java
@@ -1,0 +1,112 @@
+package io.reshapr.ctrl.webhook;
+
+import static io.restassured.RestAssured.given;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Base64;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodBuilder;
+import io.fabric8.kubernetes.api.model.admission.v1.AdmissionRequest;
+import io.fabric8.kubernetes.api.model.admission.v1.AdmissionRequestBuilder;
+import io.fabric8.kubernetes.api.model.admission.v1.AdmissionReview;
+import io.fabric8.kubernetes.api.model.admission.v1.AdmissionReviewBuilder;
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.http.ContentType;
+import jakarta.inject.Inject;
+
+@QuarkusTest
+public class MutatingWebhookResourceTest {
+
+    @Inject
+    ObjectMapper objectMapper;
+
+    @Test
+    public void testMutateWithInjection() throws Exception {
+        Pod pod = new PodBuilder()
+                .withMetadata(new ObjectMetaBuilder()
+                        .withName("test-pod")
+                        .withAnnotations(Map.of("io.reshapr/inject", "true"))
+                        .build())
+                .withNewSpec()
+                .addNewContainer()
+                .withName("app-container")
+                .withImage("app-image")
+                .endContainer()
+                .endSpec()
+                .build();
+
+        AdmissionRequest request = new AdmissionRequestBuilder()
+                .withUid("test-uid")
+                .withNewKind("Pod", "v1")
+                .withObject(pod)
+                .build();
+
+        AdmissionReview review = new AdmissionReviewBuilder()
+                .withRequest(request)
+                .build();
+
+        AdmissionReview response = given()
+                .contentType(ContentType.JSON)
+                .body(review)
+                .when()
+                .post("/api/v1/webhooks/mutate")
+                .then()
+                .statusCode(200)
+                .extract()
+                .as(AdmissionReview.class);
+
+        assertTrue(response.getResponse().getAllowed());
+        assertEquals("test-uid", response.getResponse().getUid());
+        assertEquals("JSONPatch", response.getResponse().getPatchType());
+        
+        String decodedPatch = new String(Base64.getDecoder().decode(response.getResponse().getPatch()));
+        assertTrue(decodedPatch.contains("reshapr-proxy"));
+    }
+
+    @Test
+    public void testMutateWithoutInjection() {
+        Pod pod = new PodBuilder()
+                .withMetadata(new ObjectMetaBuilder()
+                        .withName("test-pod")
+                        .build())
+                .withNewSpec()
+                .addNewContainer()
+                .withName("app-container")
+                .withImage("app-image")
+                .endContainer()
+                .endSpec()
+                .build();
+
+        AdmissionRequest request = new AdmissionRequestBuilder()
+                .withUid("test-uid")
+                .withNewKind("Pod", "v1")
+                .withObject(pod)
+                .build();
+
+        AdmissionReview review = new AdmissionReviewBuilder()
+                .withRequest(request)
+                .build();
+
+        AdmissionReview response = given()
+                .contentType(ContentType.JSON)
+                .body(review)
+                .when()
+                .post("/api/v1/webhooks/mutate")
+                .then()
+                .statusCode(200)
+                .extract()
+                .as(AdmissionReview.class);
+
+        assertTrue(response.getResponse().getAllowed());
+        assertEquals("test-uid", response.getResponse().getUid());
+        assertTrue(response.getResponse().getPatch() == null || response.getResponse().getPatch().isEmpty());
+    }
+}

--- a/control-plane/src/test/java/io/reshapr/ctrl/webhook/MutatingWebhookResourceTest.java
+++ b/control-plane/src/test/java/io/reshapr/ctrl/webhook/MutatingWebhookResourceTest.java
@@ -45,7 +45,7 @@ public class MutatingWebhookResourceTest {
 
         AdmissionRequest request = new AdmissionRequestBuilder()
                 .withUid("test-uid")
-                .withNewKind("Pod", "v1")
+                .withNewKind("", "Pod", "v1")
                 .withObject(pod)
                 .build();
 
@@ -87,7 +87,7 @@ public class MutatingWebhookResourceTest {
 
         AdmissionRequest request = new AdmissionRequestBuilder()
                 .withUid("test-uid")
-                .withNewKind("Pod", "v1")
+                .withNewKind("", "Pod", "v1")
                 .withObject(pod)
                 .build();
 


### PR DESCRIPTION
fixes #123 

It uses the `quarkus-kubernetes-client` and `zjsonpatch` to expose an `/api/v1/webhooks/mutate` endpoint that parses incoming AdmissionReview requests. If a Pod is submitted with the `io.reshapr/inject: "true"` annotation, the webhook generates a JSON patch to inject the r`eshapr-proxy` container.