### PR TITLE
ci: restrict workflow push triggers to main branch

### DIFF
--- a/.github/workflows/build-verify.yml
+++ b/.github/workflows/build-verify.yml
@@ -1,6 +1,8 @@
 name: build-verify-package
 on:
   push:
+    branches:
+      - main
     paths-ignore:
       #- '.github/**'
       - '.gitignore'


### PR DESCRIPTION
### Description

This PR optimizes the GitHub Actions workflow by restricting the `push` trigger to only execute on the `main` branch. 

Currently, pushing commits to a feature branch that has an active PR results in duplicate, redundant CI runs (one for the `push` event and one for the `pull_request` event), especially for a forked repo. By limiting the `push` trigger to `main` while maintaining the `pull_request` trigger for feature branches, this reduces CI noise and saves Actions resources, aligning with open-source CI best practices.

**Changes:**
- Updated `.github/workflows/build-verify.yml` to specify `branches: [main]` under the `push` trigger.
