### PR TITLE
Implement web-ui Step 1 (As a regular user: access to the UI control)

### DIFF
--- a/web-ui/src/lib/api/client.ts
+++ b/web-ui/src/lib/api/client.ts
@@ -1,0 +1,173 @@
+/*
+ * Copyright The Reshapr Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ApiError } from './errors.js';
+
+export { ApiError } from './errors.js';
+
+async function parseErrorBody(res: Response): Promise<string> {
+  const t = await res.text();
+  return t || res.statusText;
+}
+
+/**
+ * REST client for control-plane v1 APIs via the SvelteKit BFF proxy.
+ * Authentication is handled server-side (httpOnly cookie); no Bearer header in the browser.
+ */
+export function apiClient() {
+  const json = async <T>(path: string, init?: RequestInit): Promise<T> => {
+    const res = await fetch(path, init);
+    if (!res.ok) throw new ApiError(await parseErrorBody(res), res.status);
+    if (res.status === 204) return undefined as T;
+    const ct = res.headers.get('content-type');
+    if (ct?.includes('application/json')) return res.json() as Promise<T>;
+    return (await res.text()) as T;
+  };
+
+  const empty = async (path: string, init?: RequestInit) => {
+    const res = await fetch(path, init);
+    if (!res.ok) throw new ApiError(await parseErrorBody(res), res.status);
+  };
+
+  return {
+    listServices: () => json<unknown[]>('/api/v1/services?page=0&size=500'),
+    listServicesPage: (page: number, size: number) =>
+      json<unknown[]>(`/api/v1/services?page=${page}&size=${size}`),
+    getService: (id: string) => json<unknown>(`/api/v1/services/${id}`),
+    deleteService: (id: string) => empty(`/api/v1/services/${id}`, { method: 'DELETE' }),
+
+    listArtifactsByService: (serviceId: string) =>
+      json<unknown[]>(`/api/v1/artifacts/service/${serviceId}`),
+
+    importArtifactFile: async (file: File, extra?: Record<string, string>) => {
+      const fd = new FormData();
+      fd.append('file', file);
+      fd.append('mainArtifact', 'true');
+      if (extra?.serviceName) fd.append('serviceName', extra.serviceName);
+      if (extra?.serviceVersion) fd.append('serviceVersion', extra.serviceVersion);
+      const res = await fetch('/api/v1/artifacts', { method: 'POST', body: fd });
+      if (!res.ok) throw new ApiError(await parseErrorBody(res), res.status);
+      return res.json();
+    },
+
+    importArtifactUrl: async (params: URLSearchParams) => {
+      const res = await fetch('/api/v1/artifacts', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: params.toString()
+      });
+      if (!res.ok) throw new ApiError(await parseErrorBody(res), res.status);
+      return res.json();
+    },
+
+    attachArtifactFile: async (file: File) => {
+      const fd = new FormData();
+      fd.append('file', file);
+      const res = await fetch('/api/v1/artifacts/attach', { method: 'POST', body: fd });
+      if (!res.ok) throw new ApiError(await parseErrorBody(res), res.status);
+      return res.json();
+    },
+
+    attachArtifactUrl: async (url: string, secretName?: string) => {
+      const p = new URLSearchParams();
+      p.set('url', url);
+      if (secretName) p.set('secretName', secretName);
+      const res = await fetch('/api/v1/artifacts/attach', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: p.toString()
+      });
+      if (!res.ok) throw new ApiError(await parseErrorBody(res), res.status);
+      return res.json();
+    },
+
+    listConfigurationPlans: () => json<unknown[]>('/api/v1/configurationPlans'),
+    getConfigurationPlan: (id: string) => json<unknown>(`/api/v1/configurationPlans/${id}`),
+    createConfigurationPlan: (body: unknown) =>
+      json<unknown>('/api/v1/configurationPlans', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body)
+      }),
+    updateConfigurationPlan: (id: string, body: unknown) =>
+      json<unknown>(`/api/v1/configurationPlans/${id}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body)
+      }),
+    deleteConfigurationPlan: (id: string) =>
+      empty(`/api/v1/configurationPlans/${id}`, { method: 'DELETE' }),
+    renewApiKey: (id: string) =>
+      json<unknown>(`/api/v1/configurationPlans/${id}/renewApiKey`, { method: 'PUT' }),
+
+    listExpositionsAll: () => json<unknown[]>('/api/v1/expositions'),
+    listExpositionsActive: () => json<unknown[]>('/api/v1/expositions/active'),
+    getExposition: (id: string) => json<unknown>(`/api/v1/expositions/${id}`),
+    getActiveExposition: (id: string) => json<unknown>(`/api/v1/expositions/active/${id}`),
+    getActiveExpositionOrNull: async (id: string): Promise<unknown | null> => {
+      const res = await fetch(`/api/v1/expositions/active/${id}`);
+      if (res.status === 404) return null;
+      if (!res.ok) throw new ApiError(await parseErrorBody(res), res.status);
+      return res.json() as Promise<unknown>;
+    },
+    createExposition: (body: { configurationPlanId: string; gatewayGroupId: string }) =>
+      json<unknown>('/api/v1/expositions', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body)
+      }),
+    deleteExposition: (id: string) => empty(`/api/v1/expositions/${id}`, { method: 'DELETE' }),
+
+    listSecretRefs: () => json<unknown[]>('/api/v1/secrets/refs?page=0&size=500'),
+    listSecrets: (page = 0, size = 500) =>
+      json<unknown[]>(`/api/v1/secrets?page=${page}&size=${size}`),
+    getSecret: (id: string) => json<unknown>(`/api/v1/secrets/${id}`),
+    createSecret: (body: unknown) =>
+      json<unknown>('/api/v1/secrets', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body)
+      }),
+    updateSecret: (id: string, body: unknown) =>
+      json<unknown>(`/api/v1/secrets/${id}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body)
+      }),
+    deleteSecret: (id: string) => empty(`/api/v1/secrets/${id}`, { method: 'DELETE' }),
+
+    listGatewayGroups: () => json<unknown[]>('/api/v1/gatewayGroups'),
+    createGatewayGroup: (body: unknown) =>
+      json<unknown>('/api/v1/gatewayGroups', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body)
+      }),
+    deleteGatewayGroup: (id: string) => empty(`/api/v1/gatewayGroups/${id}`, { method: 'DELETE' }),
+
+    getQuotas: () => json<unknown>('/api/v1/quotas'),
+
+    listApiTokens: () => json<unknown[]>('/api/v1/tokens/apiTokens'),
+    createApiToken: (body: unknown) =>
+      json<unknown>('/api/v1/tokens/apiTokens', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body)
+      }),
+    deleteApiToken: (tokenId: string) =>
+      empty(`/api/v1/tokens/apiTokens/${tokenId}`, { method: 'DELETE' })
+  };
+}

--- a/web-ui/src/lib/api/errors.ts
+++ b/web-ui/src/lib/api/errors.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright The Reshapr Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export class ApiError extends Error {
+  readonly status: number;
+  readonly body: string | undefined;
+
+  constructor(message: string, status: number, body?: string) {
+    super(message);
+    this.name = 'ApiError';
+    this.status = status;
+    this.body = body;
+  }
+}

--- a/web-ui/src/lib/components/ApiErrorAlert.svelte
+++ b/web-ui/src/lib/components/ApiErrorAlert.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+	import * as Alert from '$lib/components/ui/alert/index.js';
+
+	let { message }: { message: string } = $props();
+</script>
+
+<Alert.Root variant="destructive">
+	<Alert.Title>Error</Alert.Title>
+	<Alert.Description class="whitespace-pre-wrap font-mono text-xs">{message}</Alert.Description>
+</Alert.Root>

--- a/web-ui/src/lib/components/ApiErrorAlert.svelte
+++ b/web-ui/src/lib/components/ApiErrorAlert.svelte
@@ -1,3 +1,19 @@
+<!--
+  ~ Copyright The Reshapr Authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
 <script lang="ts">
 	import * as Alert from '$lib/components/ui/alert/index.js';
 

--- a/web-ui/src/lib/components/JsonBlock.svelte
+++ b/web-ui/src/lib/components/JsonBlock.svelte
@@ -1,0 +1,9 @@
+<script lang="ts">
+	let { value, loading = false }: { value: unknown; loading?: boolean } = $props();
+
+	const text = $derived(
+		loading ? 'Loading…' : value !== undefined && value !== null ? JSON.stringify(value, null, 2) : '—'
+	);
+</script>
+
+<pre class="bg-muted overflow-x-auto rounded-lg border p-4 font-mono text-xs leading-relaxed">{text}</pre>

--- a/web-ui/src/lib/components/JsonBlock.svelte
+++ b/web-ui/src/lib/components/JsonBlock.svelte
@@ -1,3 +1,19 @@
+<!--
+  ~ Copyright The Reshapr Authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
 <script lang="ts">
 	let { value, loading = false }: { value: unknown; loading?: boolean } = $props();
 

--- a/web-ui/src/lib/components/PageHeader.svelte
+++ b/web-ui/src/lib/components/PageHeader.svelte
@@ -1,3 +1,19 @@
+<!--
+  ~ Copyright The Reshapr Authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
 <script lang="ts">
 	import type { Snippet } from 'svelte';
 

--- a/web-ui/src/lib/components/PageHeader.svelte
+++ b/web-ui/src/lib/components/PageHeader.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+
+	let {
+		title,
+		actions
+	}: {
+		title: string;
+		actions?: Snippet;
+	} = $props();
+</script>
+
+<div class="mb-6 flex flex-wrap items-center justify-between gap-4 border-b pb-4">
+	<h2 class="text-xl font-bold tracking-tight text-foreground">{title}</h2>
+	{#if actions}
+		<div class="flex flex-wrap items-center gap-2">
+			{@render actions()}
+		</div>
+	{/if}
+</div>

--- a/web-ui/src/lib/components/ScrollableCode.svelte
+++ b/web-ui/src/lib/components/ScrollableCode.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+	import { cn } from '$lib/utils.js';
+
+	let {
+		text,
+		class: className = '',
+		maxHeight = '5.5rem'
+	}: {
+		text: string;
+		class?: string;
+		/** CSS length, e.g. `5.5rem` or `24rem` */
+		maxHeight?: string;
+	} = $props();
+</script>
+
+<div
+	class={cn(
+		'bg-muted/40 overflow-auto rounded-md border px-2 py-1.5',
+		className
+	)}
+	style:max-height={maxHeight}
+	title={text}
+>
+	<code class="text-foreground block font-mono text-xs leading-relaxed break-all whitespace-pre-wrap"
+		>{text}</code>
+</div>

--- a/web-ui/src/lib/components/ScrollableCode.svelte
+++ b/web-ui/src/lib/components/ScrollableCode.svelte
@@ -1,3 +1,19 @@
+<!--
+  ~ Copyright The Reshapr Authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
 <script lang="ts">
 	import { cn } from '$lib/utils.js';
 

--- a/web-ui/src/lib/components/ui/alert/alert-action.svelte
+++ b/web-ui/src/lib/components/ui/alert/alert-action.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import type { HTMLAttributes } from "svelte/elements";
+	import { cn, type WithElementRef } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();
+</script>
+
+<div
+	bind:this={ref}
+	data-slot="alert-action"
+	class={cn("absolute top-2 right-2", className)}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/web-ui/src/lib/components/ui/alert/alert-description.svelte
+++ b/web-ui/src/lib/components/ui/alert/alert-description.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+	import type { HTMLAttributes } from "svelte/elements";
+	import { cn, type WithElementRef } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();
+</script>
+
+<div
+	bind:this={ref}
+	data-slot="alert-description"
+	class={cn(
+		"text-muted-foreground text-sm text-balance md:text-pretty [&_p:not(:last-child)]:mb-4 [&_a]:hover:text-foreground [&_a]:underline [&_a]:underline-offset-3",
+		className
+	)}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/web-ui/src/lib/components/ui/alert/alert-title.svelte
+++ b/web-ui/src/lib/components/ui/alert/alert-title.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+	import type { HTMLAttributes } from "svelte/elements";
+	import { cn, type WithElementRef } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();
+</script>
+
+<div
+	bind:this={ref}
+	data-slot="alert-title"
+	class={cn(
+		"font-medium group-has-[>svg]/alert:col-start-2 [&_a]:hover:text-foreground [&_a]:underline [&_a]:underline-offset-3",
+		className
+	)}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/web-ui/src/lib/components/ui/alert/alert.svelte
+++ b/web-ui/src/lib/components/ui/alert/alert.svelte
@@ -1,0 +1,43 @@
+<script lang="ts" module>
+	import { type VariantProps, tv } from "tailwind-variants";
+
+	export const alertVariants = tv({
+		base: "grid gap-0.5 rounded-lg border px-2.5 py-2 text-left text-sm has-data-[slot=alert-action]:relative has-data-[slot=alert-action]:pr-18 has-[>svg]:grid-cols-[auto_1fr] has-[>svg]:gap-x-2 *:[svg]:row-span-2 *:[svg]:translate-y-0.5 *:[svg]:text-current *:[svg:not([class*='size-'])]:size-4 group/alert relative w-full",
+		variants: {
+			variant: {
+				default: "bg-card text-card-foreground",
+				destructive: "text-destructive bg-card *:data-[slot=alert-description]:text-destructive/90 *:[svg]:text-current",
+			},
+		},
+		defaultVariants: {
+			variant: "default",
+		},
+	});
+
+	export type AlertVariant = VariantProps<typeof alertVariants>["variant"];
+</script>
+
+<script lang="ts">
+	import type { HTMLAttributes } from "svelte/elements";
+	import { cn, type WithElementRef } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		variant = "default",
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> & {
+		variant?: AlertVariant;
+	} = $props();
+</script>
+
+<div
+	bind:this={ref}
+	data-slot="alert"
+	role="alert"
+	class={cn(alertVariants({ variant }), className)}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/web-ui/src/lib/components/ui/alert/index.ts
+++ b/web-ui/src/lib/components/ui/alert/index.ts
@@ -1,0 +1,17 @@
+import Root from "./alert.svelte";
+import Description from "./alert-description.svelte";
+import Title from "./alert-title.svelte";
+import Action from "./alert-action.svelte";
+export { alertVariants, type AlertVariant } from "./alert.svelte";
+
+export {
+	Root,
+	Description,
+	Title,
+	Action,
+	//
+	Root as Alert,
+	Description as AlertDescription,
+	Title as AlertTitle,
+	Action as AlertAction,
+};

--- a/web-ui/src/lib/components/ui/card/index.ts
+++ b/web-ui/src/lib/components/ui/card/index.ts
@@ -1,6 +1,25 @@
-export { default as Card } from './card.svelte';
-export { default as CardHeader } from './card-header.svelte';
-export { default as CardTitle } from './card-title.svelte';
-export { default as CardDescription } from './card-description.svelte';
-export { default as CardContent } from './card-content.svelte';
+import Root from './card.svelte';
+import Content from './card-content.svelte';
+import Description from './card-description.svelte';
+import Footer from './card-footer.svelte';
+import Header from './card-header.svelte';
+import Title from './card-title.svelte';
+import Action from './card-action.svelte';
 
+export {
+  Root,
+  Content,
+  Description,
+  Footer,
+  Header,
+  Title,
+  Action,
+  //
+  Root as Card,
+  Content as CardContent,
+  Description as CardDescription,
+  Footer as CardFooter,
+  Header as CardHeader,
+  Title as CardTitle,
+  Action as CardAction
+};

--- a/web-ui/src/lib/components/ui/collapsible/collapsible-content.svelte
+++ b/web-ui/src/lib/components/ui/collapsible/collapsible-content.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import { Collapsible as CollapsiblePrimitive } from "bits-ui";
+
+	let { ref = $bindable(null), ...restProps }: CollapsiblePrimitive.ContentProps = $props();
+</script>
+
+<CollapsiblePrimitive.Content bind:ref data-slot="collapsible-content" {...restProps} />

--- a/web-ui/src/lib/components/ui/collapsible/collapsible-trigger.svelte
+++ b/web-ui/src/lib/components/ui/collapsible/collapsible-trigger.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import { Collapsible as CollapsiblePrimitive } from "bits-ui";
+
+	let { ref = $bindable(null), ...restProps }: CollapsiblePrimitive.TriggerProps = $props();
+</script>
+
+<CollapsiblePrimitive.Trigger bind:ref data-slot="collapsible-trigger" {...restProps} />

--- a/web-ui/src/lib/components/ui/collapsible/collapsible.svelte
+++ b/web-ui/src/lib/components/ui/collapsible/collapsible.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+	import { Collapsible as CollapsiblePrimitive } from "bits-ui";
+
+	let {
+		ref = $bindable(null),
+		open = $bindable(false),
+		...restProps
+	}: CollapsiblePrimitive.RootProps = $props();
+</script>
+
+<CollapsiblePrimitive.Root bind:ref bind:open data-slot="collapsible" {...restProps} />

--- a/web-ui/src/lib/components/ui/collapsible/index.ts
+++ b/web-ui/src/lib/components/ui/collapsible/index.ts
@@ -1,0 +1,13 @@
+import Root from "./collapsible.svelte";
+import Trigger from "./collapsible-trigger.svelte";
+import Content from "./collapsible-content.svelte";
+
+export {
+	Root,
+	Content,
+	Trigger,
+	//
+	Root as Collapsible,
+	Content as CollapsibleContent,
+	Trigger as CollapsibleTrigger,
+};

--- a/web-ui/src/lib/components/ui/select/index.ts
+++ b/web-ui/src/lib/components/ui/select/index.ts
@@ -1,0 +1,37 @@
+import Root from "./select.svelte";
+import Group from "./select-group.svelte";
+import Label from "./select-label.svelte";
+import Item from "./select-item.svelte";
+import Content from "./select-content.svelte";
+import Trigger from "./select-trigger.svelte";
+import Separator from "./select-separator.svelte";
+import ScrollDownButton from "./select-scroll-down-button.svelte";
+import ScrollUpButton from "./select-scroll-up-button.svelte";
+import GroupHeading from "./select-group-heading.svelte";
+import Portal from "./select-portal.svelte";
+
+export {
+	Root,
+	Group,
+	Label,
+	Item,
+	Content,
+	Trigger,
+	Separator,
+	ScrollDownButton,
+	ScrollUpButton,
+	GroupHeading,
+	Portal,
+	//
+	Root as Select,
+	Group as SelectGroup,
+	Label as SelectLabel,
+	Item as SelectItem,
+	Content as SelectContent,
+	Trigger as SelectTrigger,
+	Separator as SelectSeparator,
+	ScrollDownButton as SelectScrollDownButton,
+	ScrollUpButton as SelectScrollUpButton,
+	GroupHeading as SelectGroupHeading,
+	Portal as SelectPortal,
+};

--- a/web-ui/src/lib/components/ui/select/select-content.svelte
+++ b/web-ui/src/lib/components/ui/select/select-content.svelte
@@ -1,0 +1,45 @@
+<script lang="ts">
+	import { Select as SelectPrimitive } from "bits-ui";
+	import SelectPortal from "./select-portal.svelte";
+	import SelectScrollUpButton from "./select-scroll-up-button.svelte";
+	import SelectScrollDownButton from "./select-scroll-down-button.svelte";
+	import { cn, type WithoutChild } from "$lib/utils.js";
+	import type { ComponentProps } from "svelte";
+	import type { WithoutChildrenOrChild } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		sideOffset = 4,
+		portalProps,
+		children,
+		preventScroll = true,
+		...restProps
+	}: WithoutChild<SelectPrimitive.ContentProps> & {
+		portalProps?: WithoutChildrenOrChild<ComponentProps<typeof SelectPortal>>;
+	} = $props();
+</script>
+
+<SelectPortal {...portalProps}>
+	<SelectPrimitive.Content
+		bind:ref
+		{sideOffset}
+		{preventScroll}
+		data-slot="select-content"
+		class={cn(
+			"bg-popover text-popover-foreground data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 ring-foreground/10 min-w-36 rounded-lg shadow-md ring-1 duration-100 data-[side=inline-start]:slide-in-from-right-2 data-[side=inline-end]:slide-in-from-left-2 relative isolate z-50 overflow-x-hidden overflow-y-auto",
+			className
+		)}
+		{...restProps}
+	>
+		<SelectScrollUpButton />
+		<SelectPrimitive.Viewport
+			class={cn(
+				"h-(--bits-select-anchor-height) w-full min-w-(--bits-select-anchor-width) scroll-my-1"
+			)}
+		>
+			{@render children?.()}
+		</SelectPrimitive.Viewport>
+		<SelectScrollDownButton />
+	</SelectPrimitive.Content>
+</SelectPortal>

--- a/web-ui/src/lib/components/ui/select/select-group-heading.svelte
+++ b/web-ui/src/lib/components/ui/select/select-group-heading.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+	import { Select as SelectPrimitive } from "bits-ui";
+	import { cn } from "$lib/utils.js";
+	import type { ComponentProps } from "svelte";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: ComponentProps<typeof SelectPrimitive.GroupHeading> = $props();
+</script>
+
+<SelectPrimitive.GroupHeading
+	bind:ref
+	data-slot="select-group-heading"
+	class={cn("text-muted-foreground px-2 py-1.5 text-xs", className)}
+	{...restProps}
+>
+	{@render children?.()}
+</SelectPrimitive.GroupHeading>

--- a/web-ui/src/lib/components/ui/select/select-group.svelte
+++ b/web-ui/src/lib/components/ui/select/select-group.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+	import { Select as SelectPrimitive } from "bits-ui";
+	import { cn } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		...restProps
+	}: SelectPrimitive.GroupProps = $props();
+</script>
+
+<SelectPrimitive.Group
+	bind:ref
+	data-slot="select-group"
+	class={cn("scroll-my-1 p-1", className)}
+	{...restProps}
+/>

--- a/web-ui/src/lib/components/ui/select/select-item.svelte
+++ b/web-ui/src/lib/components/ui/select/select-item.svelte
@@ -1,0 +1,38 @@
+<script lang="ts">
+	import { Select as SelectPrimitive } from "bits-ui";
+	import { cn, type WithoutChild } from "$lib/utils.js";
+	import CheckIcon from '@lucide/svelte/icons/check';
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		value,
+		label,
+		children: childrenProp,
+		...restProps
+	}: WithoutChild<SelectPrimitive.ItemProps> = $props();
+</script>
+
+<SelectPrimitive.Item
+	bind:ref
+	{value}
+	data-slot="select-item"
+	class={cn(
+		"focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-sm [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2 focus:bg-accent data-highlighted:bg-accent data-highlighted:text-accent-foreground focus:text-accent-foreground relative flex w-full cursor-default items-center outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+		className
+	)}
+	{...restProps}
+>
+	{#snippet children({ selected, highlighted })}
+		<span class="absolute end-2 flex size-3.5 items-center justify-center">
+			{#if selected}
+				<CheckIcon class="cn-select-item-indicator-icon" />
+			{/if}
+		</span>
+		{#if childrenProp}
+			{@render childrenProp({ selected, highlighted })}
+		{:else}
+			{label || value}
+		{/if}
+	{/snippet}
+</SelectPrimitive.Item>

--- a/web-ui/src/lib/components/ui/select/select-label.svelte
+++ b/web-ui/src/lib/components/ui/select/select-label.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import { cn, type WithElementRef } from "$lib/utils.js";
+	import type { HTMLAttributes } from "svelte/elements";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> & {} = $props();
+</script>
+
+<div
+	bind:this={ref}
+	data-slot="select-label"
+	class={cn("text-muted-foreground px-1.5 py-1 text-xs", className)}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/web-ui/src/lib/components/ui/select/select-portal.svelte
+++ b/web-ui/src/lib/components/ui/select/select-portal.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import { Select as SelectPrimitive } from "bits-ui";
+
+	let { ...restProps }: SelectPrimitive.PortalProps = $props();
+</script>
+
+<SelectPrimitive.Portal {...restProps} />

--- a/web-ui/src/lib/components/ui/select/select-scroll-down-button.svelte
+++ b/web-ui/src/lib/components/ui/select/select-scroll-down-button.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import { Select as SelectPrimitive } from "bits-ui";
+	import { cn, type WithoutChildrenOrChild } from "$lib/utils.js";
+	import ChevronDownIcon from '@lucide/svelte/icons/chevron-down';
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		...restProps
+	}: WithoutChildrenOrChild<SelectPrimitive.ScrollDownButtonProps> = $props();
+</script>
+
+<SelectPrimitive.ScrollDownButton
+	bind:ref
+	data-slot="select-scroll-down-button"
+	class={cn("bg-popover z-10 flex cursor-default items-center justify-center py-1 [&_svg:not([class*='size-'])]:size-4 bottom-0 w-full", className)}
+	{...restProps}
+>
+	<ChevronDownIcon  />
+</SelectPrimitive.ScrollDownButton>

--- a/web-ui/src/lib/components/ui/select/select-scroll-up-button.svelte
+++ b/web-ui/src/lib/components/ui/select/select-scroll-up-button.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import { Select as SelectPrimitive } from "bits-ui";
+	import { cn, type WithoutChildrenOrChild } from "$lib/utils.js";
+	import ChevronUpIcon from '@lucide/svelte/icons/chevron-up';
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		...restProps
+	}: WithoutChildrenOrChild<SelectPrimitive.ScrollUpButtonProps> = $props();
+</script>
+
+<SelectPrimitive.ScrollUpButton
+	bind:ref
+	data-slot="select-scroll-up-button"
+	class={cn("bg-popover z-10 flex cursor-default items-center justify-center py-1 [&_svg:not([class*='size-'])]:size-4 top-0 w-full", className)}
+	{...restProps}
+>
+	<ChevronUpIcon  />
+</SelectPrimitive.ScrollUpButton>

--- a/web-ui/src/lib/components/ui/select/select-separator.svelte
+++ b/web-ui/src/lib/components/ui/select/select-separator.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+	import type { Separator as SeparatorPrimitive } from "bits-ui";
+	import { Separator } from "$lib/components/ui/separator/index.js";
+	import { cn } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		...restProps
+	}: SeparatorPrimitive.RootProps = $props();
+</script>
+
+<Separator
+	bind:ref
+	data-slot="select-separator"
+	class={cn("bg-border -mx-1 my-1 h-px pointer-events-none", className)}
+	{...restProps}
+/>

--- a/web-ui/src/lib/components/ui/select/select-trigger.svelte
+++ b/web-ui/src/lib/components/ui/select/select-trigger.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+	import { Select as SelectPrimitive } from "bits-ui";
+	import { cn, type WithoutChild } from "$lib/utils.js";
+	import ChevronDownIcon from '@lucide/svelte/icons/chevron-down';
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		size = "default",
+		...restProps
+	}: WithoutChild<SelectPrimitive.TriggerProps> & {
+		size?: "sm" | "default";
+	} = $props();
+</script>
+
+<SelectPrimitive.Trigger
+	bind:ref
+	data-slot="select-trigger"
+	data-size={size}
+	class={cn(
+		"border-input data-placeholder:text-muted-foreground dark:bg-input/30 dark:hover:bg-input/50 focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 gap-1.5 rounded-lg border bg-transparent py-2 pr-2 pl-2.5 text-sm transition-colors select-none focus-visible:ring-3 aria-invalid:ring-3 data-[size=default]:h-8 data-[size=sm]:h-7 data-[size=sm]:rounded-[min(var(--radius-md),10px)] *:data-[slot=select-value]:flex *:data-[slot=select-value]:gap-1.5 [&_svg:not([class*='size-'])]:size-4 flex w-fit items-center justify-between whitespace-nowrap outline-none disabled:cursor-not-allowed disabled:opacity-50 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center [&_svg]:pointer-events-none [&_svg]:shrink-0",
+		className
+	)}
+	{...restProps}
+>
+	{@render children?.()}
+	<ChevronDownIcon class="text-muted-foreground size-4 pointer-events-none" />
+</SelectPrimitive.Trigger>

--- a/web-ui/src/lib/components/ui/select/select.svelte
+++ b/web-ui/src/lib/components/ui/select/select.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+	import { Select as SelectPrimitive } from "bits-ui";
+
+	let {
+		open = $bindable(false),
+		value = $bindable(),
+		...restProps
+	}: SelectPrimitive.RootProps = $props();
+</script>
+
+<SelectPrimitive.Root bind:open bind:value={value as never} {...restProps} />

--- a/web-ui/src/lib/components/ui/textarea/index.ts
+++ b/web-ui/src/lib/components/ui/textarea/index.ts
@@ -1,0 +1,7 @@
+import Root from "./textarea.svelte";
+
+export {
+	Root,
+	//
+	Root as Textarea,
+};

--- a/web-ui/src/lib/components/ui/textarea/textarea.svelte
+++ b/web-ui/src/lib/components/ui/textarea/textarea.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+	import { cn, type WithElementRef, type WithoutChildren } from "$lib/utils.js";
+	import type { HTMLTextareaAttributes } from "svelte/elements";
+
+	let {
+		ref = $bindable(null),
+		value = $bindable(),
+		class: className,
+		"data-slot": dataSlot = "textarea",
+		...restProps
+	}: WithoutChildren<WithElementRef<HTMLTextareaAttributes>> = $props();
+</script>
+
+<textarea
+	bind:this={ref}
+	data-slot={dataSlot}
+	class={cn(
+		"border-input dark:bg-input/30 focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 disabled:bg-input/50 dark:disabled:bg-input/80 rounded-lg border bg-transparent px-2.5 py-2 text-base transition-colors focus-visible:ring-3 aria-invalid:ring-3 md:text-sm placeholder:text-muted-foreground flex field-sizing-content min-h-16 w-full outline-none disabled:cursor-not-allowed disabled:opacity-50",
+		className
+	)}
+	bind:value
+	{...restProps}
+></textarea>

--- a/web-ui/src/lib/dashboardStats.ts
+++ b/web-ui/src/lib/dashboardStats.ts
@@ -1,0 +1,99 @@
+import { apiClient } from '$lib/api/client.js';
+import {
+  buildGatewayRegisteredDetail,
+  quotaUsed,
+  type GatewayRegisteredDetail
+} from '$lib/dashboardStatsCompute.js';
+
+export type { GatewayRegisteredDetail, GatewayRowDetail } from '$lib/dashboardStatsCompute'
+export {
+	aggregateGatewaysFromActiveExpositions,
+	buildGatewayRegisteredDetail,
+	quotaEntry
+} from '$lib/dashboardStatsCompute'
+
+type Api = ReturnType<typeof apiClient>
+
+export type DashboardStats = {
+	/** Current tenant (JWT); not a platform-wide org list. */
+	organizationId: string | null
+	serviceCount: number
+	/** From quotas (`gateway.count` used) when available, else active exposition gateways. */
+	gatewayRegisteredCount: number
+	/** Gateways on active expositions with at least one FQDN (best-effort without heartbeat API). */
+	gatewayHealthyCount: number
+	gatewayGroupsCount: number | null
+	expositionCount: number | null
+	/** Not exposed on GET /api/v1/* — always null until upstream adds an endpoint. */
+	userCount: null
+	/** Not exposed on GET /api/v1/* — always null until upstream adds an endpoint. */
+	organizationCount: null
+	gatewayRegisteredDetail: GatewayRegisteredDetail
+}
+
+async function countAllServices(c: Api): Promise<{ count: number; organizationId: string | null }> {
+	const size = 100
+	let page = 0
+	let total = 0
+	let organizationId: string | null = null
+	for (;;) {
+		const batch = await c.listServicesPage(page, size)
+		if (!Array.isArray(batch) || batch.length === 0) break
+		if (!organizationId && batch[0] && typeof batch[0] === 'object') {
+			const id = (batch[0] as Record<string, unknown>).organizationId
+			if (typeof id === 'string' && id) organizationId = id
+		}
+		total += batch.length
+		if (batch.length < size) break
+		page += 1
+	}
+	return { count: total, organizationId }
+}
+
+function pickOrganizationId(services: unknown[], gatewayGroups: unknown[]): string | null {
+	for (const raw of services) {
+		if (raw && typeof raw === 'object') {
+			const id = (raw as Record<string, unknown>).organizationId
+			if (typeof id === 'string' && id) return id
+		}
+	}
+	for (const raw of gatewayGroups) {
+		if (raw && typeof raw === 'object') {
+			const id = (raw as Record<string, unknown>).organizationId
+			if (typeof id === 'string' && id) return id
+		}
+	}
+	return null
+}
+
+/** Dashboard metrics using only existing v1 REST APIs (no control-plane changes). */
+export async function loadDashboardStats(): Promise<DashboardStats> {
+	const c = apiClient()
+
+	const [services, activeExpositions, quotas, gatewayGroups] = await Promise.all([
+		countAllServices(c),
+		c.listExpositionsActive(),
+		c.getQuotas(),
+		c.listGatewayGroups()
+	])
+
+	const active = Array.isArray(activeExpositions) ? activeExpositions : []
+	const gatewayRegisteredDetail = buildGatewayRegisteredDetail(active, quotas)
+	const fromActive = gatewayRegisteredDetail.fromActiveExpositions
+
+	const orgId =
+		services.organizationId ??
+		pickOrganizationId([], Array.isArray(gatewayGroups) ? gatewayGroups : [])
+
+	return {
+		organizationId: orgId,
+		serviceCount: services.count,
+		gatewayRegisteredCount: gatewayRegisteredDetail.displayedCount,
+		gatewayHealthyCount: fromActive.healthy,
+		gatewayGroupsCount: quotaUsed(quotas, 'gateway-group.count'),
+		expositionCount: quotaUsed(quotas, 'exposition.count'),
+		userCount: null,
+		organizationCount: null,
+		gatewayRegisteredDetail
+	}
+}

--- a/web-ui/src/lib/dashboardStats.ts
+++ b/web-ui/src/lib/dashboardStats.ts
@@ -1,3 +1,19 @@
+/*
+ * Copyright The Reshapr Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { apiClient } from '$lib/api/client.js';
 import {
   buildGatewayRegisteredDetail,

--- a/web-ui/src/lib/dashboardStatsCompute.ts
+++ b/web-ui/src/lib/dashboardStatsCompute.ts
@@ -1,0 +1,133 @@
+export type GatewayRowDetail = {
+	key: string
+	id?: string
+	name?: string
+	hasFqdn: boolean
+	/** Exposition id or name where this gateway appears (active list). */
+	onActiveExpositions: string[]
+}
+
+export type GatewayRegisteredDetail = {
+	displayedCount: number
+	/** How the card value was chosen. */
+	source: 'quota_only' | 'active_expositions_only' | 'max_quota_and_active'
+	quota: { metric: string; used: number; limit: number; remaining: number } | null
+	fromActiveExpositions: {
+		registered: number
+		healthy: number
+		gateways: GatewayRowDetail[]
+	}
+}
+
+type GatewayRow = { id?: string; name?: string; fqdns?: unknown[] }
+
+function expositionLabel(expo: Record<string, unknown>): string {
+	if (typeof expo.id === 'string' && expo.id) return expo.id
+	if (typeof expo.name === 'string' && expo.name) return expo.name
+	return '(exposition)'
+}
+
+/** Dedupe gateways by `id`, else `name`, across GET /api/v1/expositions/active. */
+export function aggregateGatewaysFromActiveExpositions(active: unknown[]): {
+	registered: number
+	healthy: number
+	gateways: GatewayRowDetail[]
+} {
+	const byKey = new Map<string, GatewayRowDetail>()
+	for (const expo of active) {
+		if (!expo || typeof expo !== 'object') continue
+		const expoObj = expo as Record<string, unknown>
+		const expoId = expositionLabel(expoObj)
+		const gws = expoObj.gateways
+		if (!Array.isArray(gws)) continue
+		for (const g of gws) {
+			if (!g || typeof g !== 'object') continue
+			const row = g as GatewayRow
+			const key =
+				typeof row.id === 'string' && row.id
+					? row.id
+					: typeof row.name === 'string' && row.name
+						? row.name
+						: null
+			if (!key) continue
+			const fqdns = Array.isArray(row.fqdns) ? row.fqdns : []
+			const hasFqdn = fqdns.some((f) => typeof f === 'string' && f.trim().length > 0)
+			const existing = byKey.get(key)
+			if (existing) {
+				existing.hasFqdn = existing.hasFqdn || hasFqdn
+				if (!existing.onActiveExpositions.includes(expoId)) {
+					existing.onActiveExpositions.push(expoId)
+				}
+			} else {
+				byKey.set(key, {
+					key,
+					id: typeof row.id === 'string' ? row.id : undefined,
+					name: typeof row.name === 'string' ? row.name : undefined,
+					hasFqdn,
+					onActiveExpositions: [expoId]
+				})
+			}
+		}
+	}
+	const gateways = [...byKey.values()].sort((a, b) => a.key.localeCompare(b.key))
+	let healthy = 0
+	for (const g of gateways) {
+		if (g.hasFqdn) healthy += 1
+	}
+	return { registered: gateways.length, healthy, gateways }
+}
+
+export function quotaEntry(
+	quotas: unknown,
+	metric: string
+): { used: number; limit: number; remaining: number } | null {
+	if (!Array.isArray(quotas)) return null
+	for (const q of quotas) {
+		if (!q || typeof q !== 'object') continue
+		const o = q as Record<string, unknown>
+		if (o.metric !== metric) continue
+		const limit = Number(o.limit)
+		const remaining = Number(o.remaining)
+		if (!Number.isFinite(limit) || !Number.isFinite(remaining)) return null
+		return { used: Math.max(0, limit - remaining), limit, remaining }
+	}
+	return null
+}
+
+export function quotaUsed(quotas: unknown, metric: string): number | null {
+	return quotaEntry(quotas, metric)?.used ?? null
+}
+
+export function buildGatewayRegisteredDetail(
+	activeExpositions: unknown[],
+	quotas: unknown
+): GatewayRegisteredDetail {
+	const fromActive = aggregateGatewaysFromActiveExpositions(
+		Array.isArray(activeExpositions) ? activeExpositions : []
+	)
+	const quota = quotaEntry(quotas, 'gateway.count')
+	const fromQuota = quota?.used ?? null
+
+	let displayedCount: number
+	let source: GatewayRegisteredDetail['source']
+	if (fromQuota == null) {
+		displayedCount = fromActive.registered
+		source = 'active_expositions_only'
+	} else {
+		displayedCount = Math.max(fromQuota, fromActive.registered)
+		if (displayedCount === fromQuota && fromQuota > fromActive.registered) {
+			source = 'quota_only'
+		} else if (displayedCount === fromActive.registered && fromActive.registered > fromQuota) {
+			source = 'active_expositions_only'
+		} else {
+			source = 'max_quota_and_active'
+		}
+	}
+
+	return {
+		displayedCount,
+		source,
+		quota: quota ? { metric: 'gateway.count', ...quota } : null,
+		fromActiveExpositions: fromActive
+	}
+}

--- a/web-ui/src/lib/dashboardStatsCompute.ts
+++ b/web-ui/src/lib/dashboardStatsCompute.ts
@@ -1,3 +1,19 @@
+/*
+ * Copyright The Reshapr Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 export type GatewayRowDetail = {
 	key: string
 	id?: string

--- a/web-ui/src/lib/format-api-error.ts
+++ b/web-ui/src/lib/format-api-error.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright The Reshapr Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ApiError } from '$lib/api/errors.js';
+
+export function formatApiError(e: unknown): string {
+  if (!(e instanceof ApiError)) return String(e);
+  const body = e.message.length > 1200 ? `${e.message.slice(0, 1200)}…` : e.message;
+  return `HTTP ${e.status}: ${body}`;
+}

--- a/web-ui/src/lib/mcpCustomTools.ts
+++ b/web-ui/src/lib/mcpCustomTools.ts
@@ -1,3 +1,19 @@
+/*
+ * Copyright The Reshapr Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /**
  * Resolves MCP custom tools from an endpoint URL and control-plane REST APIs
  * (artifacts `RESHAPR_CUSTOM_TOOLS` and service operations, filtered by exposition).

--- a/web-ui/src/lib/mcpCustomTools.ts
+++ b/web-ui/src/lib/mcpCustomTools.ts
@@ -1,0 +1,353 @@
+/**
+ * Resolves MCP custom tools from an endpoint URL and control-plane REST APIs
+ * (artifacts `RESHAPR_CUSTOM_TOOLS` and service operations, filtered by exposition).
+ */
+
+export type McpCustomToolsClient = {
+  listServicesPage: (page: number, size: number) => Promise<unknown[]>
+  listExpositionsActive: () => Promise<unknown[]>
+  listExpositionsAll: () => Promise<unknown[]>
+  getExposition: (id: string) => Promise<unknown>
+  listArtifactsByService: (serviceId: string) => Promise<unknown[]>
+  getService: (id: string) => Promise<unknown>
+}
+
+export type McpCustomToolRow = {
+  name: string
+  description: string
+  inputSchema: Record<string, unknown>
+}
+
+export type McpCustomToolsResolution = {
+  tools: McpCustomToolRow[]
+  source: 'artifacts_custom_tools' | 'services_operations'
+  expoId: string
+  serviceId: string
+  /** Full `RESHAPR_CUSTOM_TOOLS` artifact YAML when tools come from that artifact. */
+  artifactYaml?: string
+}
+
+import { parseMcpUrl } from './mcpUrl'
+
+export { parseMcpUrl } from './mcpUrl'
+
+function parseInputSchemaFromYamlBlock(block: string): { type: string; properties: Record<string, unknown> } {
+  const m = block.match(/^    input:\s*\n([\s\S]+)/m)
+  if (!m) return { type: 'object', properties: {} }
+  const body = m[1]
+  const properties: Record<string, Record<string, unknown>> = {}
+  let cur: string | null = null
+  for (const line of body.split('\n')) {
+    const prop = line.match(/^        ([a-zA-Z0-9_]+):\s*$/)
+    if (prop) {
+      cur = prop[1]
+      properties[cur] = {}
+      continue
+    }
+    if (!cur) continue
+    const typ = line.match(/^          type:\s*(.+)$/)
+    if (typ) properties[cur].type = typ[1].trim()
+    const desc = line.match(/^          description:\s*(.+)$/)
+    if (desc) properties[cur].description = desc[1].trim()
+    const def = line.match(/^          default:\s*(.+)$/)
+    if (def) {
+      const v = def[1].trim()
+      properties[cur].default = /^\d+$/.test(v) ? Number(v) : v
+    }
+  }
+  return { type: 'object', properties }
+}
+
+type ParsedYamlTool = {
+  name: string
+  tool: string
+  description: string
+  inputSchema: { type: string; properties: Record<string, unknown> }
+}
+
+function parseReshaprCustomToolsYaml(content: string): ParsedYamlTool[] {
+  if (!content || typeof content !== 'string') return []
+  const marker = 'customTools:'
+  const idx = content.indexOf(marker)
+  if (idx === -1) return []
+  let rest = content.slice(idx + marker.length)
+  rest = rest.replace(/^\s*\n/, '')
+  const tools: ParsedYamlTool[] = []
+  const keyRe = /^  ([a-zA-Z0-9_]+):\s*$/gm
+  const keys: { name: string; start: number; endHeader: number }[] = []
+  let mm: RegExpExecArray | null
+  while ((mm = keyRe.exec(rest)) !== null) {
+    keys.push({ name: mm[1], start: mm.index, endHeader: mm.index + mm[0].length })
+  }
+  for (let i = 0; i < keys.length; i++) {
+    const block = rest.slice(keys[i].endHeader, i + 1 < keys.length ? keys[i + 1].start : rest.length)
+    const toolLine = block.match(/^\s{4}tool:\s*(.+)$/m)
+    const titleLine = block.match(/^\s{4}title:\s*(.+)$/m)
+    let description = ''
+    const folded = block.match(/^\s{4}description:\s*>\s*\n([\s\S]*?)(?=^\s{4}(?:input|tool|title):)/m)
+    if (folded) {
+      description = folded[1]
+        .split('\n')
+        .map((l) => l.trim())
+        .filter(Boolean)
+        .join(' ')
+        .trim()
+    } else {
+      const inlineD = block.match(/^\s{4}description:\s*(.+)$/m)
+      if (inlineD) description = inlineD[1].trim()
+    }
+    const inputSchema = parseInputSchemaFromYamlBlock(block)
+    tools.push({
+      name: keys[i].name,
+      tool: toolLine ? toolLine[1].trim() : '',
+      description: description || (titleLine ? titleLine[1].trim() : ''),
+      inputSchema,
+    })
+  }
+  return tools
+}
+
+function includedOperationsList(value: unknown): string[] {
+  if (value == null) return []
+  if (Array.isArray(value)) return value.map(String)
+  return []
+}
+
+function filterCustomToolsByIncluded(tools: ParsedYamlTool[], included: string[]): ParsedYamlTool[] {
+  if (!included.length) return tools
+  const set = new Set(included)
+  return tools.filter((t) => t.tool && set.has(t.tool))
+}
+
+function toolNameFromOperation(operationName: string): string {
+  let s = String(operationName || '').trim()
+  if (!s) return 'unnamed_tool'
+  s = s.replace(/[^a-zA-Z0-9]+/g, '_').replace(/_+/g, '_')
+  if (/^[0-9]/.test(s)) s = `op_${s}`
+  return s
+}
+
+function fqdnToHost(fqdn: string): string {
+  const s = String(fqdn || '').trim()
+  if (!s) return ''
+  try {
+    if (/^https?:\/\//i.test(s)) return new URL(s).host
+  } catch {
+    // ignore
+  }
+  return s.split('/')[0].trim()
+}
+
+type ExpoListRow = {
+  id?: string
+  createdOn?: string
+  service?: { id?: string }
+  gateways?: { fqdns?: unknown[] }[]
+}
+
+function expositionMatchesHost(expo: ExpoListRow, serviceId: string, mcpHost: string): boolean {
+  if (!expo?.service?.id || expo.service.id !== serviceId) return false
+  const gateways = Array.isArray(expo.gateways) ? expo.gateways : []
+  for (const g of gateways) {
+    const fqdns = Array.isArray(g?.fqdns) ? g.fqdns : []
+    for (const fqdn of fqdns) {
+      if (typeof fqdn === 'string' && fqdnToHost(fqdn) === mcpHost) return true
+    }
+  }
+  return false
+}
+
+function pickNewestExposition(expos: ExpoListRow[]): ExpoListRow | null {
+  if (!Array.isArray(expos) || expos.length === 0) return null
+  const sorted = [...expos].sort((a, b) =>
+    String(b.createdOn || '').localeCompare(String(a.createdOn || '')),
+  )
+  return sorted[0] ?? null
+}
+
+async function listAllServices(client: McpCustomToolsClient): Promise<unknown[]> {
+  const size = 100
+  let page = 0
+  const out: unknown[] = []
+  for (;;) {
+    const batch = await client.listServicesPage(page, size)
+    if (!Array.isArray(batch) || batch.length === 0) break
+    out.push(...batch)
+    if (batch.length < size) break
+    page += 1
+  }
+  return out
+}
+
+async function resolveExpositionForMcp(
+  client: McpCustomToolsClient,
+  serviceId: string,
+  mcpHost: string,
+): Promise<unknown> {
+  const active = (await client.listExpositionsActive()) as ExpoListRow[]
+  const activeList = Array.isArray(active) ? active : []
+  const fromActive = pickNewestExposition(
+    activeList.filter((e) => expositionMatchesHost(e, serviceId, mcpHost)),
+  )
+  if (fromActive?.id) {
+    return client.getExposition(fromActive.id)
+  }
+  const all = (await client.listExpositionsAll()) as ExpoListRow[]
+  const allList = Array.isArray(all) ? all : []
+  const fromAll = pickNewestExposition(
+    allList.filter((e) => expositionMatchesHost(e, serviceId, mcpHost)),
+  )
+  if (!fromAll?.id) return null
+  return client.getExposition(fromAll.id)
+}
+
+type ServiceRow = {
+  id?: string
+  organizationId?: string
+  name?: string
+  version?: string
+}
+
+type ArtifactRow = {
+  type?: string
+  content?: string | null
+}
+
+type ExpoDetail = {
+  id?: string
+  configurationPlan?: { includedOperations?: unknown }
+}
+
+type ServiceView = {
+  operations?: { name?: string }[]
+}
+
+async function resolveExpositionForService(
+  client: McpCustomToolsClient,
+  serviceId: string,
+  mcpHost?: string,
+): Promise<ExpoDetail | null> {
+  if (mcpHost) {
+    const raw = await resolveExpositionForMcp(client, serviceId, mcpHost)
+    return raw as ExpoDetail | null
+  }
+  const active = (await client.listExpositionsActive()) as ExpoListRow[]
+  const activeList = Array.isArray(active) ? active : []
+  const fromActive = pickNewestExposition(
+    activeList.filter((e) => e?.service?.id === serviceId),
+  )
+  if (fromActive?.id) {
+    return (await client.getExposition(fromActive.id)) as ExpoDetail
+  }
+  const all = (await client.listExpositionsAll()) as ExpoListRow[]
+  const allList = Array.isArray(all) ? all : []
+  const fromAll = pickNewestExposition(allList.filter((e) => e?.service?.id === serviceId))
+  if (!fromAll?.id) return null
+  return (await client.getExposition(fromAll.id)) as ExpoDetail
+}
+
+export async function resolveMcpCustomToolsForService(
+  serviceId: string,
+  client: McpCustomToolsClient,
+  options?: { exposition?: ExpoDetail | null },
+): Promise<McpCustomToolsResolution> {
+  const view = (await client.getService(serviceId)) as ServiceRow & ServiceView
+  if (!view?.id) {
+    throw new Error(`Service not found: ${serviceId}`)
+  }
+  const expo =
+    options && 'exposition' in options
+      ? (options.exposition ?? null)
+      : await resolveExpositionForService(client, serviceId)
+  if (!expo?.id) {
+    const artifacts = (await client.listArtifactsByService(serviceId)) as ArtifactRow[]
+    const artifactList = Array.isArray(artifacts) ? artifacts : []
+    const yamlArtifact = artifactList.find((a) => a && a.type === 'RESHAPR_CUSTOM_TOOLS' && a.content)
+    const customParsed = parseReshaprCustomToolsYaml(yamlArtifact?.content || '')
+    if (customParsed.length > 0) {
+      const customOut: McpCustomToolRow[] = customParsed.map((t) => ({
+        name: t.name,
+        description: t.description || '',
+        inputSchema: (t.inputSchema || { type: 'object', properties: {} }) as Record<string, unknown>,
+      }))
+      return {
+        tools: customOut,
+        source: 'artifacts_custom_tools',
+        expoId: '',
+        serviceId,
+        artifactYaml: yamlArtifact?.content ?? undefined,
+      }
+    }
+    const ops = Array.isArray(view?.operations) ? view.operations : []
+    const restOut: McpCustomToolRow[] = ops.map((op) => ({
+      name: toolNameFromOperation(String(op.name)),
+      description: String(op.name),
+      inputSchema: { type: 'object' },
+    }))
+    return {
+      tools: restOut,
+      source: 'services_operations',
+      expoId: '',
+      serviceId,
+    }
+  }
+  const included = includedOperationsList(expo.configurationPlan?.includedOperations)
+  const artifacts = (await client.listArtifactsByService(serviceId)) as ArtifactRow[]
+  const artifactList = Array.isArray(artifacts) ? artifacts : []
+  const yamlArtifact = artifactList.find((a) => a && a.type === 'RESHAPR_CUSTOM_TOOLS' && a.content)
+  const customParsed = parseReshaprCustomToolsYaml(yamlArtifact?.content || '')
+  const customFiltered = filterCustomToolsByIncluded(customParsed, included)
+  const customOut: McpCustomToolRow[] = customFiltered.map((t) => ({
+    name: t.name,
+    description: t.description || '',
+    inputSchema: (t.inputSchema || { type: 'object', properties: {} }) as Record<string, unknown>,
+  }))
+  if (customOut.length > 0) {
+    return {
+      tools: customOut,
+      source: 'artifacts_custom_tools',
+      expoId: expo.id,
+      serviceId,
+      artifactYaml: yamlArtifact?.content ?? undefined,
+    }
+  }
+  const ops = Array.isArray(view?.operations) ? view.operations : []
+  const includedSet = new Set(included)
+  const restOps = included.length ? ops.filter((o) => o && includedSet.has(String(o.name))) : ops
+  const restOut: McpCustomToolRow[] = restOps.map((op) => ({
+    name: toolNameFromOperation(String(op.name)),
+    description: String(op.name),
+    inputSchema: { type: 'object' },
+  }))
+  return {
+    tools: restOut,
+    source: 'services_operations',
+    expoId: expo.id,
+    serviceId,
+  }
+}
+
+export async function resolveMcpCustomToolsFromUrl(
+  mcpUrl: string,
+  client: McpCustomToolsClient,
+): Promise<McpCustomToolsResolution> {
+  const { orgId, serviceName, version, host } = parseMcpUrl(mcpUrl)
+  const services = (await listAllServices(client)) as ServiceRow[]
+  const service = services.find(
+    (s) =>
+      s &&
+      s.organizationId === orgId &&
+      s.name === serviceName &&
+      s.version === version,
+  )
+  if (!service?.id) {
+    throw new Error(`Service not found for ${orgId} / ${serviceName} / ${version}`)
+  }
+  const expoRaw = await resolveExpositionForService(client, service.id, host)
+  if (!expoRaw?.id) {
+    throw new Error(
+      'No exposition (active or full list) has FQDNs matching the MCP URL host for this service',
+    )
+  }
+  return resolveMcpCustomToolsForService(service.id, client, { exposition: expoRaw })
+}

--- a/web-ui/src/lib/mcpEndpointUrls.ts
+++ b/web-ui/src/lib/mcpEndpointUrls.ts
@@ -1,0 +1,139 @@
+/**
+ * Construction des URLs MCP à partir des DTO expositions actives du control-plane,
+ * alignée sur la CLI Reshapr : {@link https://github.com/reshaprio/reshapr/blob/main/cli/src/utils/format.ts formatEndpoint}
+ * et la liste {@link https://github.com/reshaprio/reshapr/blob/main/cli/src/commands/expo.ts expo list} (expositions actives).
+ *
+ * Aucune lecture BDD ni CLI : uniquement les réponses JSON des routes `/api/v1/expositions/...`.
+ */
+
+/** Même encodage que `encodeUrl` dans format.ts (espaces → '+'). */
+export function encodeMcpPathSegment(value: string): string {
+  return value.replace(/\s/g, '+')
+}
+
+/**
+ * Équivalent à `formatEndpoint` + normalisation en URL HTTP absolue pour le navigateur
+ * (les FQDN API sont souvent `hôte:port` sans schéma, comme dans la sortie CLI).
+ */
+export function buildAbsoluteMcpUrl(
+  fqdn: string,
+  organizationId: string,
+  serviceName: string,
+  serviceVersion: string,
+): string {
+  const relPath = `mcp/${organizationId}/${encodeMcpPathSegment(serviceName)}/${encodeMcpPathSegment(serviceVersion)}`
+  const raw = fqdn.trim()
+  if (!raw) throw new Error('FQDN vide')
+  if (/^https?:\/\//i.test(raw)) {
+    const base = raw.replace(/\/+$/, '')
+    return new URL(relPath, `${base}/`).href
+  }
+  return new URL(relPath, `http://${raw.replace(/^\/+/, '')}/`).href
+}
+
+export type McpUrlListItem = {
+  url: string
+  expositionId: string
+  organizationId: string
+  serviceId: string
+  serviceName: string
+  serviceVersion: string
+  fqdn: string
+  gatewayName?: string
+}
+
+type GatewayRow = { name?: string; fqdns?: unknown[] }
+
+type ActiveExpositionLike = {
+  id?: string
+  organizationId?: string
+  service?: { id?: string; name?: string; version?: string }
+  gateways?: GatewayRow[]
+}
+
+function rowsFromActivePayload(payload: unknown): ActiveExpositionLike[] {
+  if (Array.isArray(payload)) return payload as ActiveExpositionLike[]
+  if (payload && typeof payload === 'object') return [payload as ActiveExpositionLike]
+  return []
+}
+
+/** À partir d’objets au même format que `GET /api/v1/expositions/active` (liste ou détail actif). */
+export function collectMcpUrlsFromActiveExpositions(payload: unknown): McpUrlListItem[] {
+  const rows = rowsFromActivePayload(payload)
+  const out: McpUrlListItem[] = []
+  for (const row of rows) {
+    const expositionId = String(row.id || '')
+    const organizationId = String(row.organizationId || '')
+    const svc = row.service
+    const serviceId = String(svc?.id || '')
+    const serviceName = String(svc?.name || '')
+    const serviceVersion = String(svc?.version || '')
+    if (!expositionId || !organizationId || !serviceId || !serviceName) continue
+    const gateways = Array.isArray(row.gateways) ? row.gateways : []
+    for (const g of gateways) {
+      const fqdns = Array.isArray(g?.fqdns) ? g.fqdns : []
+      const gatewayName = typeof g?.name === 'string' ? g.name : undefined
+      for (const fq of fqdns) {
+        if (typeof fq !== 'string' || !fq.trim()) continue
+        try {
+          out.push({
+            url: buildAbsoluteMcpUrl(fq, organizationId, serviceName, serviceVersion),
+            expositionId,
+            organizationId,
+            serviceId,
+            serviceName,
+            serviceVersion,
+            fqdn: fq.trim(),
+            gatewayName,
+          })
+        } catch {
+          // FQDN invalide : on ignore cette entrée
+        }
+      }
+    }
+  }
+  return out
+}
+
+export type ListMcpUrlsDeps = {
+  listExpositionsActive: () => Promise<unknown[]>
+  listExpositionsAll: () => Promise<unknown[]>
+  getActiveExpositionOrNull: (id: string) => Promise<unknown | null>
+}
+
+/**
+ * - `active` : un seul appel `GET /api/v1/expositions/active` (équivalent `expo list` sans `--all`).
+ * - `all` : `GET /api/v1/expositions` puis pour chaque id `GET /api/v1/expositions/active/{id}` (404 ignoré),
+ *   comme quand la CLI affiche les endpoints seulement pour une exposition réellement active.
+ */
+function dedupeByUrl(items: McpUrlListItem[]): McpUrlListItem[] {
+  const seen = new Set<string>()
+  const out: McpUrlListItem[] = []
+  for (const item of items) {
+    if (seen.has(item.url)) continue
+    seen.add(item.url)
+    out.push(item)
+  }
+  return out
+}
+
+export async function listMcpEndpointUrls(mode: 'active' | 'all', deps: ListMcpUrlsDeps): Promise<McpUrlListItem[]> {
+  if (mode === 'active') {
+    const rows = await deps.listExpositionsActive()
+    return dedupeByUrl(collectMcpUrlsFromActiveExpositions(Array.isArray(rows) ? rows : []))
+  }
+
+  const all = await deps.listExpositionsAll()
+  const list = Array.isArray(all) ? all : []
+  const merged: McpUrlListItem[] = []
+  for (const raw of list) {
+    if (!raw || typeof raw !== 'object' || !('id' in raw)) continue
+    const id = String((raw as { id: unknown }).id || '')
+    if (!id) continue
+    const active = await deps.getActiveExpositionOrNull(id)
+    if (active === null) continue
+    merged.push(...collectMcpUrlsFromActiveExpositions(active))
+  }
+
+  return dedupeByUrl(merged)
+}

--- a/web-ui/src/lib/mcpEndpointUrls.ts
+++ b/web-ui/src/lib/mcpEndpointUrls.ts
@@ -1,3 +1,19 @@
+/*
+ * Copyright The Reshapr Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /**
  * Construction des URLs MCP à partir des DTO expositions actives du control-plane,
  * alignée sur la CLI Reshapr : {@link https://github.com/reshaprio/reshapr/blob/main/cli/src/utils/format.ts formatEndpoint}

--- a/web-ui/src/lib/mcpPrompts.ts
+++ b/web-ui/src/lib/mcpPrompts.ts
@@ -1,0 +1,177 @@
+/**
+ * Resolves MCP prompts from an MCP URL via control-plane REST
+ * (artifact `RESHAPR_PROMPTS`), avoiding browser CORS on the MCP gateway.
+ */
+
+import type { McpPromptArgument, McpPromptDescriptor } from './mcpTypes.js';
+import { parseMcpUrl } from './mcpUrl.js';
+
+export type McpPromptsClient = {
+  listServicesPage: (page: number, size: number) => Promise<unknown[]>
+  listArtifactsByService: (serviceId: string) => Promise<unknown[]>
+}
+
+export type McpPromptArtifactYaml = {
+  name: string
+  content: string
+}
+
+export type McpPromptsResolution = {
+  prompts: McpPromptDescriptor[]
+  source: 'artifacts_prompts'
+  serviceId: string
+  artifactNames: string[]
+  /** Full YAML content per `RESHAPR_PROMPTS` artifact. */
+  artifactYamls: McpPromptArtifactYaml[]
+}
+
+type ServiceRow = {
+  id?: string
+  organizationId?: string
+  name?: string
+  version?: string
+}
+
+type ArtifactRow = {
+  type?: string
+  name?: string
+  content?: string | null
+}
+
+async function listAllServices(client: McpPromptsClient): Promise<unknown[]> {
+  const size = 100
+  let page = 0
+  const out: unknown[] = []
+  for (;;) {
+    const batch = await client.listServicesPage(page, size)
+    if (!Array.isArray(batch) || batch.length === 0) break
+    out.push(...batch)
+    if (batch.length < size) break
+    page += 1
+  }
+  return out
+}
+
+function parsePromptArguments(block: string): McpPromptArgument[] {
+  const argsMarker = block.match(/^\s{4}arguments:\s*$/m)
+  if (!argsMarker || argsMarker.index === undefined) return []
+
+  const after = block.slice(argsMarker.index + argsMarker[0].length)
+  const args: McpPromptArgument[] = []
+  const items = after.split(/^\s{6}-\s+/m).slice(1)
+  for (const item of items) {
+    const name = item.match(/^\s*name:\s*(.+)$/m)?.[1]?.trim()
+    if (!name) continue
+    const description = item.match(/^\s*description:\s*(.+)$/m)?.[1]?.trim()
+    const requiredLine = item.match(/^\s*required:\s*(true|false)\s*$/m)?.[1]
+    const arg: McpPromptArgument = { name }
+    if (description) arg.description = description
+    if (requiredLine === 'true') arg.required = true
+    args.push(arg)
+  }
+  return args
+}
+
+/** Parse `prompts:` block from a Reshapr Prompts YAML artifact. */
+export function parseReshaprPromptsYaml(content: string): McpPromptDescriptor[] {
+  if (!content || typeof content !== 'string') return []
+  const marker = 'prompts:'
+  const idx = content.indexOf(marker)
+  if (idx === -1) return []
+
+  let rest = content.slice(idx + marker.length).replace(/^\s*\n/, '')
+  const keyRe = /^  ([a-zA-Z0-9_]+):\s*$/gm
+  const keys: { name: string; endHeader: number; start: number }[] = []
+  let mm: RegExpExecArray | null
+  while ((mm = keyRe.exec(rest)) !== null) {
+    keys.push({ name: mm[1], start: mm.index, endHeader: mm.index + mm[0].length })
+  }
+
+  const prompts: McpPromptDescriptor[] = []
+  for (let i = 0; i < keys.length; i++) {
+    const block = rest.slice(keys[i].endHeader, i + 1 < keys.length ? keys[i + 1].start : rest.length)
+    const titleLine = block.match(/^\s{4}title:\s*(.+)$/m)
+    let description = ''
+    const folded = block.match(/^\s{4}description:\s*>\s*\n([\s\S]*?)(?=^\s{4}(?:arguments|title|result):)/m)
+    if (folded) {
+      description = folded[1]
+        .split('\n')
+        .map((l) => l.trim())
+        .filter(Boolean)
+        .join(' ')
+        .trim()
+    } else {
+      const inlineD = block.match(/^\s{4}description:\s*(.+)$/m)
+      if (inlineD) description = inlineD[1].trim()
+    }
+    const arguments_ = parsePromptArguments(block)
+    const prompt: McpPromptDescriptor = {
+      name: keys[i].name,
+      description: description || (titleLine ? titleLine[1].trim() : undefined),
+    }
+    if (arguments_.length) prompt.arguments = arguments_
+    prompts.push(prompt)
+  }
+  return prompts
+}
+
+export async function resolveMcpPromptsForService(
+  serviceId: string,
+  client: McpPromptsClient,
+): Promise<McpPromptsResolution> {
+  const artifacts = (await client.listArtifactsByService(serviceId)) as ArtifactRow[]
+  const promptArtifacts = (Array.isArray(artifacts) ? artifacts : []).filter(
+    (a) => a?.type === 'RESHAPR_PROMPTS' && a.content,
+  )
+  if (promptArtifacts.length === 0) {
+    return {
+      prompts: [],
+      source: 'artifacts_prompts',
+      serviceId,
+      artifactNames: [],
+      artifactYamls: [],
+    }
+  }
+
+  const byName = new Map<string, McpPromptDescriptor>()
+  const artifactNames: string[] = []
+  const artifactYamls: McpPromptArtifactYaml[] = []
+  for (const artifact of promptArtifacts) {
+    const label = artifact.name || `RESHAPR_PROMPTS-${artifactYamls.length + 1}`
+    if (artifact.name) artifactNames.push(artifact.name)
+    if (artifact.content) {
+      artifactYamls.push({ name: label, content: artifact.content })
+    }
+    for (const p of parseReshaprPromptsYaml(artifact.content || '')) {
+      byName.set(p.name, p)
+    }
+  }
+
+  return {
+    prompts: [...byName.values()],
+    source: 'artifacts_prompts',
+    serviceId,
+    artifactNames,
+    artifactYamls,
+  }
+}
+
+export async function resolveMcpPromptsFromUrl(
+  mcpUrl: string,
+  client: McpPromptsClient,
+): Promise<McpPromptsResolution> {
+  const { orgId, serviceName, version } = parseMcpUrl(mcpUrl)
+  const services = (await listAllServices(client)) as ServiceRow[]
+  const service = services.find(
+    (s) =>
+      s &&
+      s.organizationId === orgId &&
+      s.name === serviceName &&
+      s.version === version,
+  )
+  if (!service?.id) {
+    throw new Error(`Service not found for ${orgId} / ${serviceName} / ${version}`)
+  }
+
+  return resolveMcpPromptsForService(service.id, client)
+}

--- a/web-ui/src/lib/mcpPrompts.ts
+++ b/web-ui/src/lib/mcpPrompts.ts
@@ -1,3 +1,19 @@
+/*
+ * Copyright The Reshapr Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /**
  * Resolves MCP prompts from an MCP URL via control-plane REST
  * (artifact `RESHAPR_PROMPTS`), avoiding browser CORS on the MCP gateway.

--- a/web-ui/src/lib/mcpTypes.ts
+++ b/web-ui/src/lib/mcpTypes.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright The Reshapr Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export type McpPromptArgument = {
+  name: string;
+  description?: string;
+  required?: boolean;
+};
+
+export type McpPromptDescriptor = {
+  name: string;
+  description?: string;
+  arguments?: McpPromptArgument[];
+};

--- a/web-ui/src/lib/mcpUrl.ts
+++ b/web-ui/src/lib/mcpUrl.ts
@@ -1,0 +1,23 @@
+/** Parse MCP exposition URL path: /mcp/{organization}/{service}/{version} */
+
+export function parseMcpUrl(mcpUrl: string): {
+  orgId: string
+  serviceName: string
+  version: string
+  host: string
+} {
+  let u: URL
+  try {
+    u = new URL(mcpUrl)
+  } catch {
+    throw new Error('Invalid MCP URL')
+  }
+  const parts = u.pathname.split('/').filter(Boolean)
+  if (parts.length < 4 || String(parts[0]).toLowerCase() !== 'mcp') {
+    throw new Error('Expected MCP path: /mcp/{organization}/{service}/{version}')
+  }
+  const orgId = decodeURIComponent(parts[1].replace(/\+/g, '%20'))
+  const serviceName = decodeURIComponent(parts[2].replace(/\+/g, '%20'))
+  const version = decodeURIComponent(parts.slice(3).join('/').replace(/\+/g, '%20'))
+  return { orgId, serviceName, version, host: u.host }
+}

--- a/web-ui/src/lib/mcpUrl.ts
+++ b/web-ui/src/lib/mcpUrl.ts
@@ -1,3 +1,19 @@
+/*
+ * Copyright The Reshapr Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /** Parse MCP exposition URL path: /mcp/{organization}/{service}/{version} */
 
 export function parseMcpUrl(mcpUrl: string): {

--- a/web-ui/src/lib/operationsList.ts
+++ b/web-ui/src/lib/operationsList.ts
@@ -1,0 +1,26 @@
+/** Parse CLI-style operation lists (--io / --eo): JSON array or one operation per line. */
+export function parseOperationsList(text: string): string[] {
+	const trimmed = text.trim();
+	if (!trimmed) return [];
+
+	if (trimmed.startsWith('[')) {
+		const parsed = JSON.parse(trimmed) as unknown;
+		if (!Array.isArray(parsed)) {
+			throw new Error('Operations must be a JSON array of strings.');
+		}
+		return parsed.map(String).filter((s) => s.length > 0);
+	}
+
+	return trimmed
+		.split(/\r?\n/)
+		.map((line) => line.trim())
+		.filter((line) => line.length > 0 && !line.startsWith('#'));
+}
+
+export function formatOperationsList(ops: unknown): string {
+	if (ops == null) return '';
+	if (Array.isArray(ops)) {
+		return ops.map(String).filter(Boolean).join('\n');
+	}
+	return '';
+}

--- a/web-ui/src/lib/operationsList.ts
+++ b/web-ui/src/lib/operationsList.ts
@@ -1,3 +1,19 @@
+/*
+ * Copyright The Reshapr Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /** Parse CLI-style operation lists (--io / --eo): JSON array or one operation per line. */
 export function parseOperationsList(text: string): string[] {
 	const trimmed = text.trim();

--- a/web-ui/src/lib/server/auth.ts
+++ b/web-ui/src/lib/server/auth.ts
@@ -78,10 +78,7 @@ export function getSessionToken(cookies: Cookies): string | null {
   return cookies.get(SESSION_COOKIE) ?? null;
 }
 
-/**
- * Extract user profile from a JWT token string.
- * Returns { username, email, org } or null if decoding fails.
- */
+/** Extract user profile from a JWT token string. */
 export function extractUserProfile(token: string): { username: string; email: string; org: string } | null {
   const payload = decodeJwtPayload(token);
   if (!payload) return null;
@@ -93,5 +90,44 @@ export function extractUserProfile(token: string): { username: string; email: st
   if (!username || !org) return null;
 
   return { username, email: email ?? '', org };
+}
+
+function readStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter((g): g is string => typeof g === 'string');
+}
+
+function readRealmAccessRoles(payload: Record<string, unknown>): string[] {
+  const realmAccess = payload.realm_access;
+  if (!realmAccess || typeof realmAccess !== 'object') return [];
+  return readStringArray((realmAccess as Record<string, unknown>).roles);
+}
+
+/** Extended session fields for the Account page (display only; no signature verification). */
+export function extractSessionClaims(token: string): {
+  groups: string[];
+  roles: string[];
+  expiresAt: string | null;
+  expired: boolean;
+} {
+  const payload = decodeJwtPayload(token);
+  if (!payload) {
+    return { groups: [], roles: [], expiresAt: null, expired: false };
+  }
+
+  const groups = readStringArray(payload.groups);
+  const roles = [
+    ...readStringArray(payload.roles),
+    ...readRealmAccessRoles(payload)
+  ];
+
+  let expiresAt: string | null = null;
+  let expired = false;
+  if (typeof payload.exp === 'number' && Number.isFinite(payload.exp)) {
+    expiresAt = new Date(payload.exp * 1000).toISOString();
+    expired = payload.exp * 1000 <= Date.now();
+  }
+
+  return { groups, roles, expiresAt, expired };
 }
 

--- a/web-ui/src/lib/server/proxy.ts
+++ b/web-ui/src/lib/server/proxy.ts
@@ -67,13 +67,10 @@ export async function proxyRequest(
 
   const init: RequestInit = {
     method: request.method,
-    headers
+    headers,
+    // Preserve the original body stream (required for multipart FormData uploads).
+    ...(request.method !== 'GET' && request.method !== 'HEAD' ? { body: request.body, duplex: 'half' as const } : {})
   };
-
-  // Forward body for methods that have one.
-  if (!['GET', 'HEAD'].includes(request.method)) {
-    init.body = await request.text();
-  }
 
   const res = await fetch(targetUrl, init);
 

--- a/web-ui/src/lib/serviceContext.ts
+++ b/web-ui/src/lib/serviceContext.ts
@@ -1,0 +1,12 @@
+import type { ServiceRecord } from '$lib/serviceHub.js';
+
+export const SERVICE_CONTEXT_KEY = Symbol('service-context');
+
+export type ServiceContextValue = {
+	id: string;
+	service: ServiceRecord | null;
+	raw: unknown;
+	loading: boolean;
+	error: string | null;
+	refresh: () => Promise<void>;
+};

--- a/web-ui/src/lib/serviceContext.ts
+++ b/web-ui/src/lib/serviceContext.ts
@@ -1,3 +1,19 @@
+/*
+ * Copyright The Reshapr Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import type { ServiceRecord } from '$lib/serviceHub.js';
 
 export const SERVICE_CONTEXT_KEY = Symbol('service-context');

--- a/web-ui/src/lib/serviceHub.ts
+++ b/web-ui/src/lib/serviceHub.ts
@@ -1,0 +1,109 @@
+import type { apiClient } from '$lib/api/client.js';
+import { resolveMcpCustomToolsForService } from '$lib/mcpCustomTools.js';
+import { resolveMcpPromptsForService } from '$lib/mcpPrompts.js';
+import { collectMcpUrlsFromActiveExpositions } from '$lib/mcpEndpointUrls.js';
+
+export type ServiceApi = ReturnType<typeof apiClient>;
+
+export type ServiceRecord = {
+	id: string;
+	name: string;
+	version: string;
+	type: string;
+	organizationId: string | null;
+	operationsCount: number;
+};
+
+export type ServiceHubSummary = {
+	service: ServiceRecord;
+	artifactCount: number;
+	planCount: number;
+	expositionActiveCount: number;
+	expositionAllCount: number;
+	mcpCustomToolsCount: number | null;
+	mcpPromptsCount: number | null;
+	mcpUrlCount: number;
+};
+
+function asRecord(raw: unknown): Record<string, unknown> | null {
+	return raw && typeof raw === 'object' ? (raw as Record<string, unknown>) : null;
+}
+
+export function parseServiceRecord(raw: unknown): ServiceRecord | null {
+	const o = asRecord(raw);
+	if (!o || typeof o.id !== 'string') return null;
+	const ops = o.operations;
+	const operationsCount = Array.isArray(ops) ? ops.length : 0;
+	return {
+		id: o.id,
+		name: typeof o.name === 'string' ? o.name : '—',
+		version: typeof o.version === 'string' ? o.version : '—',
+		type: o.type != null ? String(o.type) : '—',
+		organizationId: typeof o.organizationId === 'string' ? o.organizationId : null,
+		operationsCount
+	};
+}
+
+export function expositionBelongsToService(raw: unknown, serviceId: string): boolean {
+	const o = asRecord(raw);
+	const svc = asRecord(o?.service);
+	return svc?.id === serviceId;
+}
+
+export function planBelongsToService(raw: unknown, serviceId: string): boolean {
+	const o = asRecord(raw);
+	return o?.serviceId === serviceId;
+}
+
+export async function loadServiceHubSummary(
+	serviceId: string,
+	client: ServiceApi,
+): Promise<ServiceHubSummary> {
+	const raw = await client.getService(serviceId);
+	const service = parseServiceRecord(raw);
+	if (!service) {
+		throw new Error(`Service not found: ${serviceId}`);
+	}
+
+	const [artifacts, plans, activeExpos, allExpos] = await Promise.all([
+		client.listArtifactsByService(serviceId),
+		client.listConfigurationPlans(),
+		client.listExpositionsActive(),
+		client.listExpositionsAll()
+	]);
+
+	const artifactList = Array.isArray(artifacts) ? artifacts : [];
+	const planList = (Array.isArray(plans) ? plans : []).filter((p) =>
+		planBelongsToService(p, serviceId),
+	);
+	const activeList = (Array.isArray(activeExpos) ? activeExpos : []).filter((e) =>
+		expositionBelongsToService(e, serviceId),
+	);
+	const allList = (Array.isArray(allExpos) ? allExpos : []).filter((e) =>
+		expositionBelongsToService(e, serviceId),
+	);
+
+	const mcpUrls = collectMcpUrlsFromActiveExpositions(activeList);
+
+	let mcpCustomToolsCount: number | null = null;
+	let mcpPromptsCount: number | null = null;
+	try {
+		const tools = await resolveMcpCustomToolsForService(serviceId, client);
+		mcpCustomToolsCount = tools.tools.length;
+	} catch {
+		mcpCustomToolsCount = null;
+	}
+	const prompts = await resolveMcpPromptsForService(serviceId, client);
+	mcpPromptsCount = prompts.prompts.length;
+
+	return {
+		service,
+		artifactCount: artifactList.length,
+		planCount: planList.length,
+		expositionActiveCount: activeList.length,
+		expositionAllCount: allList.length,
+		mcpCustomToolsCount,
+		mcpPromptsCount,
+		mcpUrlCount: mcpUrls.length
+	};
+}

--- a/web-ui/src/lib/serviceHub.ts
+++ b/web-ui/src/lib/serviceHub.ts
@@ -1,3 +1,19 @@
+/*
+ * Copyright The Reshapr Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import type { apiClient } from '$lib/api/client.js';
 import { resolveMcpCustomToolsForService } from '$lib/mcpCustomTools.js';
 import { resolveMcpPromptsForService } from '$lib/mcpPrompts.js';

--- a/web-ui/src/lib/types.ts
+++ b/web-ui/src/lib/types.ts
@@ -27,6 +27,10 @@ export interface User {
   username: string;
   email: string;
   org: string;
+  groups?: string[];
+  roles?: string[];
+  expiresAt?: string | null;
+  expired?: boolean;
 }
 
 /** User profile returned by /api/v1/user/profile. */

--- a/web-ui/src/lib/utils/relativeAge.ts
+++ b/web-ui/src/lib/utils/relativeAge.ts
@@ -1,0 +1,20 @@
+/** Relative age from an ISO-8601 instant (e.g. control plane `LocalDateTime` JSON). */
+export function formatRelativeAge(createdOn: string | undefined): string {
+	if (!createdOn) return '—';
+	const t = Date.parse(createdOn);
+	if (Number.isNaN(t)) return '—';
+	const diffMs = Date.now() - t;
+	if (diffMs < 0) return '0s';
+	const sec = Math.floor(diffMs / 1000);
+	if (sec < 60) return `${sec}s`;
+	const min = Math.floor(sec / 60);
+	if (min < 60) return `${min}m`;
+	const h = Math.floor(min / 60);
+	if (h < 48) return `${h}h`;
+	const d = Math.floor(h / 24);
+	if (d < 90) return `${d}d`;
+	const mo = Math.floor(d / 30);
+	if (mo < 24) return `${mo}mo`;
+	const y = Math.floor(d / 365);
+	return `${y}y`;
+}

--- a/web-ui/src/lib/utils/relativeAge.ts
+++ b/web-ui/src/lib/utils/relativeAge.ts
@@ -1,3 +1,19 @@
+/*
+ * Copyright The Reshapr Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /** Relative age from an ISO-8601 instant (e.g. control plane `LocalDateTime` JSON). */
 export function formatRelativeAge(createdOn: string | undefined): string {
 	if (!createdOn) return '—';

--- a/web-ui/src/routes/(app)/+layout.svelte
+++ b/web-ui/src/routes/(app)/+layout.svelte
@@ -21,6 +21,8 @@
   import { auth } from '$lib/stores/auth.svelte.js';
   import { sidebar } from '$lib/stores/sidebar.svelte.js';
   import { getBootstrapConfig } from '$lib/api/config.js';
+  import { cn } from '$lib/utils.js';
+  import * as Collapsible from '$lib/components/ui/collapsible/index.js';
   import { HugeiconsIcon } from '@hugeicons/svelte';
   import {
     DashboardSquare01Icon,
@@ -29,7 +31,9 @@
     SidebarLeft01Icon,
     SidebarRight01Icon,
     ChevronDownIcon,
-    Building01Icon
+    Building01Icon,
+    UserIcon,
+    FlaskConicalIcon
   } from '@hugeicons/core-free-icons';
 
   let { children } = $props();
@@ -37,6 +41,19 @@
   let version = $state('');
   let userMenuOpen = $state(false);
   let orgSelectorOpen = $state(false);
+  let experimentalOpen = $state(false);
+
+  const experimentalNav = [
+    { href: '/artifacts', label: 'Artifacts' },
+    { href: '/plans', label: 'Plans' },
+    { href: '/expositions', label: 'Expositions' },
+    { href: '/mcp-custom-tools', label: 'MCP custom tools' },
+    { href: '/mcp-prompts', label: 'MCP prompts' },
+    { href: '/secrets', label: 'Secrets' },
+    { href: '/gateway-groups', label: 'Gateway groups' },
+    { href: '/quotas', label: 'Quotas' },
+    { href: '/api-tokens', label: 'API tokens' },
+  ] as const;
 
   onMount(async () => {
     const hasSession = await auth.initSession();
@@ -71,6 +88,7 @@
       items: [
         { href: '/', label: 'Dashboard', icon: DashboardSquare01Icon },
         { href: '/services', label: 'Services', icon: ApiIcon },
+        { href: '/account', label: 'Account', icon: UserIcon },
       ]
     },
     {
@@ -85,7 +103,32 @@
   function isActive(href: string): boolean {
     const path = page.url.pathname;
     if (href === '/') return path === '/';
-    return path.startsWith(href);
+    if (href === '/services') {
+      return path === '/services' || path.startsWith('/services/');
+    }
+    if (href === '/plans') {
+      return path === '/plans' || path.startsWith('/plans/');
+    }
+    return path === href || path.startsWith(href + '/');
+  }
+
+  function isExperimentalActive(): boolean {
+    return experimentalNav.some((item) => isActive(item.href));
+  }
+
+  $effect(() => {
+    if (isExperimentalActive()) {
+      experimentalOpen = true;
+    }
+  });
+
+  function experimentalNavClass(href: string): string {
+    return cn(
+      'block rounded-md px-2 py-1.5 text-sm transition-colors',
+      isActive(href)
+        ? 'bg-sidebar-accent font-medium text-sidebar-accent-foreground'
+        : 'text-sidebar-foreground/80 hover:bg-sidebar-accent/50 hover:text-sidebar-accent-foreground'
+    );
   }
 
   function handleSignOut() {
@@ -241,6 +284,32 @@
             {/each}
           {/if}
         {/each}
+
+        {#if !sidebar.collapsed}
+          <Collapsible.Root bind:open={experimentalOpen} class="mt-4">
+            <Collapsible.Trigger
+              class={cn(
+                'flex w-full items-center gap-3 rounded-md px-2 py-2 text-sm font-medium transition-colors',
+                isExperimentalActive()
+                  ? 'bg-sidebar-accent text-sidebar-accent-foreground'
+                  : 'text-sidebar-foreground hover:bg-sidebar-accent/50'
+              )}
+            >
+              <span class="flex h-5 w-5 shrink-0 items-center justify-center">
+                <HugeiconsIcon icon={FlaskConicalIcon} size={18} />
+              </span>
+              <span class="flex-1 text-left">Experimental</span>
+              <span class={cn('inline-flex shrink-0 transition-transform duration-200', experimentalOpen && 'rotate-180')}>
+                <HugeiconsIcon icon={ChevronDownIcon} size={14} />
+              </span>
+            </Collapsible.Trigger>
+            <Collapsible.Content class="mt-1 space-y-0.5 pl-2">
+              {#each experimentalNav as item (item.href)}
+                <a href={item.href} class={experimentalNavClass(item.href)}>{item.label}</a>
+              {/each}
+            </Collapsible.Content>
+          </Collapsible.Root>
+        {/if}
       </nav>
 
       <!-- User profile at bottom -->
@@ -293,7 +362,7 @@
 
     <!-- Main content -->
     <main class="flex flex-1 flex-col overflow-y-auto">
-      <div class="flex-1">
+      <div class="flex-1 p-6">
         {@render children()}
       </div>
 

--- a/web-ui/src/routes/(app)/+page.svelte
+++ b/web-ui/src/routes/(app)/+page.svelte
@@ -1,63 +1,230 @@
-<!--
-  ~ Copyright The Reshapr Authors.
-  ~
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
-  ~
-  ~ http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
-  -->
-
 <script lang="ts">
-  import { auth } from '$lib/stores/auth.svelte.js';
-  import { HugeiconsIcon } from '@hugeicons/svelte';
-  import { ApiIcon, Building01Icon } from '@hugeicons/core-free-icons';
+	import { apiClient, ApiError } from '$lib/api/client.js';
+	import ApiErrorAlert from '$lib/components/ApiErrorAlert.svelte';
+	import PageHeader from '$lib/components/PageHeader.svelte';
+	import { loadDashboardStats, type DashboardStats } from '$lib/dashboardStats.js';
+	import { auth } from '$lib/stores/auth.svelte.js';
+	import { Button } from '$lib/components/ui/button/index.js';
+	import * as Card from '$lib/components/ui/card/index.js';
+	import * as Collapsible from '$lib/components/ui/collapsible/index.js';
+	import Activity from '@lucide/svelte/icons/activity';
+	import Layers from '@lucide/svelte/icons/layers';
+	import Network from '@lucide/svelte/icons/network';
+	import Server from '@lucide/svelte/icons/server';
+
+	let stats = $state<DashboardStats | null>(null);
+	let error = $state<string | null>(null);
+	let loading = $state(true);
+	let gatewayDetailOpen = $state(false);
+
+	const gatewaySourceLabel: Record<
+		NonNullable<DashboardStats['gatewayRegisteredDetail']>['source'],
+		string
+	> = {
+		quota_only: 'Quota gateway.count (used > active expositions)',
+		active_expositions_only: 'Active expositions only',
+		max_quota_and_active: 'Max(quota, active expositions)'
+	};
+
+	async function load() {
+		loading = true;
+		error = null;
+		try {
+			stats = await loadDashboardStats();
+		} catch (e) {
+			error = e instanceof ApiError ? e.message : String(e);
+			stats = null;
+		} finally {
+			loading = false;
+		}
+	}
+
+	$effect(() => {
+		if (auth.isAuthenticated) void load();
+	});
+
+	function fmt(n: number | null | undefined): string {
+		if (loading) return '…';
+		if (n == null) return '—';
+		return String(n);
+	}
 </script>
 
 <svelte:head>
-  <title>Dashboard — reShapr</title>
+	<title>Dashboard — reShapr</title>
 </svelte:head>
 
-<div class="p-6">
-  <div class="space-y-6">
-    <div>
-      <h1 class="text-2xl font-bold tracking-tight">Dashboard</h1>
-      <p class="text-muted-foreground">
-        Welcome back, <strong>{auth.user?.username}</strong>.
-        You're working in the <strong>{auth.user?.org}</strong> organization.
-      </p>
-    </div>
+<PageHeader title="Dashboard">
+	{#snippet actions()}
+		<Button variant="outline" disabled={loading} onclick={() => void load()}>Refresh</Button>
+	{/snippet}
+</PageHeader>
 
-    <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-      <a
-        href="/services"
-        class="group rounded-lg border border-border bg-card p-6 transition-colors hover:border-primary/50 hover:bg-accent/50"
-      >
-        <div class="mb-2 text-primary">
-          <HugeiconsIcon icon={ApiIcon} size={28} />
-        </div>
-        <h2 class="font-semibold text-card-foreground group-hover:text-primary">Services</h2>
-        <p class="mt-1 text-sm text-muted-foreground">Browse and manage your API services.</p>
-      </a>
+<p class="text-muted-foreground mb-4 text-sm">
+	Summary for <strong>your organization</strong> ({auth.currentOrg}), using v1 APIs exposed by the control plane.
+</p>
 
-      {#if auth.isAdmin}
-        <a
-          href="/admin/organizations"
-          class="group rounded-lg border border-border bg-card p-6 transition-colors hover:border-primary/50 hover:bg-accent/50"
-        >
-          <div class="mb-2 text-primary">
-            <HugeiconsIcon icon={Building01Icon} size={28} />
-          </div>
-          <h2 class="font-semibold text-card-foreground group-hover:text-primary">Organizations</h2>
-          <p class="mt-1 text-sm text-muted-foreground">Manage organizations and users.</p>
-        </a>
-      {/if}
-    </div>
-  </div>
+{#if error}
+	<ApiErrorAlert message={error} />
+{/if}
+
+<div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+	<!-- Platform user/org counts: no v1 API — see docs/issue-admin-api-platform-dashboard.md
+	<Card.Root class="opacity-90">
+		<Card.Header class="flex flex-row items-center justify-between pb-2">
+			<Card.Title class="text-sm font-medium">Users (platform)</Card.Title>
+			<Users class="text-muted-foreground size-4" />
+		</Card.Header>
+		<Card.Content>
+			<p class="text-3xl font-bold tracking-tight">{fmt(stats?.userCount)}</p>
+			<p class="text-muted-foreground mt-1 text-xs">Not available on v1 API</p>
+		</Card.Content>
+	</Card.Root>
+
+	<Card.Root class="opacity-90">
+		<Card.Header class="flex flex-row items-center justify-between pb-2">
+			<Card.Title class="text-sm font-medium">Organizations (platform)</Card.Title>
+			<Building2 class="text-muted-foreground size-4" />
+		</Card.Header>
+		<Card.Content>
+			<p class="text-3xl font-bold tracking-tight">{fmt(stats?.organizationCount)}</p>
+			<p class="text-muted-foreground mt-1 text-xs">
+				Current org: <code class="text-xs">{stats?.organizationId ?? '…'}</code>
+			</p>
+		</Card.Content>
+	</Card.Root>
+	-->
+
+	<Card.Root>
+		<Card.Header class="flex flex-row items-center justify-between pb-2">
+			<Card.Title class="text-sm font-medium">Services</Card.Title>
+			<Server class="text-muted-foreground size-4" />
+		</Card.Header>
+		<Card.Content>
+			<p class="text-3xl font-bold tracking-tight">{fmt(stats?.serviceCount)}</p>
+			<p class="text-muted-foreground mt-1 text-xs">Registered (current organization)</p>
+			<a href="/services" class="text-primary mt-2 inline-block text-xs font-medium hover:underline">
+				View services
+			</a>
+		</Card.Content>
+	</Card.Root>
+
+	<Card.Root>
+		<Card.Header class="flex flex-row items-center justify-between pb-2">
+			<Card.Title class="text-sm font-medium">Gateways registered</Card.Title>
+			<Network class="text-muted-foreground size-4" />
+		</Card.Header>
+		<Card.Content class="space-y-3">
+			<p class="text-3xl font-bold tracking-tight">{fmt(stats?.gatewayRegisteredCount)}</p>
+			<p class="text-muted-foreground text-xs">Quota or active expositions (see breakdown)</p>
+			{#if stats?.gatewayRegisteredDetail}
+				{@const d = stats.gatewayRegisteredDetail}
+				<Collapsible.Root bind:open={gatewayDetailOpen}>
+					<Collapsible.Trigger
+						class="text-primary text-xs font-medium hover:underline"
+						type="button"
+					>
+						{gatewayDetailOpen ? 'Hide' : 'Show'} calculation breakdown
+					</Collapsible.Trigger>
+					<Collapsible.Content class="mt-3 space-y-3 text-xs">
+						<p class="text-muted-foreground">
+							<strong>Displayed source:</strong>
+							{gatewaySourceLabel[d.source]}
+						</p>
+						{#if d.quota}
+							<div class="bg-muted/50 rounded-lg border p-3">
+								<p class="font-medium">Quota <code>gateway.count</code></p>
+								<ul class="text-muted-foreground mt-1 list-inside list-disc space-y-0.5">
+									<li>used = limit − remaining = {d.quota.limit} − {d.quota.remaining} =
+										<strong class="text-foreground">{d.quota.used}</strong></li>
+								</ul>
+							</div>
+						{:else}
+							<p class="text-muted-foreground">Quota <code>gateway.count</code> not available.</p>
+						{/if}
+						<div class="bg-muted/50 rounded-lg border p-3">
+							<p class="font-medium">
+								GET <code>/api/v1/expositions/active</code> — gateways deduplicated by id/name
+							</p>
+							<p class="text-muted-foreground mt-1">
+								{d.fromActiveExpositions.registered} unique gateway(s), {d.fromActiveExpositions.healthy}
+								with FQDN (healthy)
+							</p>
+							{#if d.fromActiveExpositions.gateways.length === 0}
+								<p class="text-muted-foreground mt-2">No gateways on active expositions.</p>
+							{:else}
+								<ul class="mt-2 max-h-48 space-y-2 overflow-y-auto">
+									{#each d.fromActiveExpositions.gateways as gw (gw.key)}
+										<li class="rounded border bg-background px-2 py-1.5">
+											<span class="font-mono text-foreground">{gw.key}</span>
+											{#if gw.name && gw.name !== gw.key}
+												<span class="text-muted-foreground"> — {gw.name}</span>
+											{/if}
+											<span class="text-muted-foreground">
+												· FQDN: {gw.hasFqdn ? 'yes' : 'no'}
+											</span>
+											<br />
+											<span class="text-muted-foreground">
+												expositions: {gw.onActiveExpositions.join(', ')}
+											</span>
+										</li>
+									{/each}
+								</ul>
+							{/if}
+						</div>
+						<p class="text-muted-foreground">
+							Card value = {#if d.quota}
+								max({d.quota.used}, {d.fromActiveExpositions.registered}) = <strong
+									class="text-foreground">{d.displayedCount}</strong
+								>
+							{:else}
+								{d.fromActiveExpositions.registered}
+							{/if}
+						</p>
+					</Collapsible.Content>
+				</Collapsible.Root>
+			{/if}
+		</Card.Content>
+	</Card.Root>
+
+	<Card.Root>
+		<Card.Header class="flex flex-row items-center justify-between pb-2">
+			<Card.Title class="text-sm font-medium">Gateways healthy</Card.Title>
+			<Activity class="text-primary size-4" />
+		</Card.Header>
+		<Card.Content>
+			<p class="text-3xl font-bold tracking-tight text-primary">{fmt(stats?.gatewayHealthyCount)}</p>
+			<p class="text-muted-foreground mt-1 text-xs">Active expositions + FQDN</p>
+		</Card.Content>
+	</Card.Root>
+
+	<Card.Root>
+		<Card.Header class="flex flex-row items-center justify-between pb-2">
+			<Card.Title class="text-sm font-medium">Gateway groups</Card.Title>
+			<Layers class="text-muted-foreground size-4" />
+		</Card.Header>
+		<Card.Content>
+			<p class="text-3xl font-bold tracking-tight">{fmt(stats?.gatewayGroupsCount)}</p>
+			<p class="text-muted-foreground mt-1 text-xs">Via quotas (used)</p>
+		</Card.Content>
+	</Card.Root>
+
+	<Card.Root>
+		<Card.Header class="flex flex-row items-center justify-between pb-2">
+			<Card.Title class="text-sm font-medium">Expositions</Card.Title>
+			<Layers class="text-muted-foreground size-4" />
+		</Card.Header>
+		<Card.Content>
+			<p class="text-3xl font-bold tracking-tight">{fmt(stats?.expositionCount)}</p>
+			<p class="text-muted-foreground mt-1 text-xs">Via quotas (used)</p>
+		</Card.Content>
+	</Card.Root>
+</div>
+
+<div class="mt-8 flex flex-wrap gap-2">
+	<Button variant="outline" href="/services">Services</Button>
+	<Button variant="outline" href="/expositions">Expositions</Button>
+	<Button variant="outline" href="/gateway-groups">Gateway groups</Button>
+	<Button variant="outline" href="/quotas">Quotas</Button>
+	<Button variant="outline" href="/artifacts">Artifacts</Button>
 </div>

--- a/web-ui/src/routes/(app)/+page.svelte
+++ b/web-ui/src/routes/(app)/+page.svelte
@@ -1,3 +1,19 @@
+<!--
+  ~ Copyright The Reshapr Authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
 <script lang="ts">
 	import { apiClient, ApiError } from '$lib/api/client.js';
 	import ApiErrorAlert from '$lib/components/ApiErrorAlert.svelte';

--- a/web-ui/src/routes/(app)/account/+page.svelte
+++ b/web-ui/src/routes/(app)/account/+page.svelte
@@ -1,0 +1,141 @@
+<!--
+  ~ Copyright The Reshapr Authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<script lang="ts">
+  import PageHeader from '$lib/components/PageHeader.svelte';
+  import { auth } from '$lib/stores/auth.svelte.js';
+  import { getBootstrapConfig } from '$lib/api/config.js';
+  import * as Alert from '$lib/components/ui/alert/index.js';
+  import * as Card from '$lib/components/ui/card/index.js';
+  import { onMount } from 'svelte';
+
+  let version = $state('');
+  let mode = $state('');
+
+  onMount(async () => {
+    try {
+      const config = await getBootstrapConfig();
+      version = config.version;
+      mode = config.mode;
+    } catch {
+      // Non-critical.
+    }
+  });
+
+  function formatTokenExpiry(iso: string | null | undefined): string {
+    if (!iso) return '—';
+    try {
+      return new Date(iso).toLocaleString();
+    } catch {
+      return '—';
+    }
+  }
+</script>
+
+<svelte:head>
+  <title>Account — reShapr</title>
+</svelte:head>
+
+<div>
+  <PageHeader title="Account" />
+
+  <p class="text-muted-foreground mb-6 text-sm">
+    Profile information is read from your server session. The control plane validates access on each API call.
+  </p>
+
+  {#if !auth.user}
+    <Alert.Root variant="destructive">
+      <Alert.Title>Unable to read session</Alert.Title>
+      <Alert.Description class="text-sm">
+        No active session. Sign out and sign in again.
+      </Alert.Description>
+    </Alert.Root>
+  {:else}
+    {#if auth.user.expired}
+      <Alert.Root class="mb-6" variant="destructive">
+        <Alert.Title>Session expired</Alert.Title>
+        <Alert.Description class="text-sm">
+          Your session has expired. Sign out and sign in again to continue.
+        </Alert.Description>
+      </Alert.Root>
+    {/if}
+
+    <div class="grid gap-4 sm:grid-cols-2">
+      <Card.Root>
+        <Card.Header>
+          <Card.Title class="text-base">Identity</Card.Title>
+        </Card.Header>
+        <Card.Content class="space-y-3 text-sm">
+          <div>
+            <p class="text-muted-foreground text-xs">Username</p>
+            <p class="font-medium">{auth.user.username ?? '—'}</p>
+          </div>
+          <div>
+            <p class="text-muted-foreground text-xs">Email</p>
+            <p class="font-medium">{auth.user.email ?? '—'}</p>
+          </div>
+          <div>
+            <p class="text-muted-foreground text-xs">Groups</p>
+            <p class="font-medium">
+              {auth.user.groups && auth.user.groups.length > 0 ? auth.user.groups.join(', ') : '—'}
+            </p>
+          </div>
+          <div>
+            <p class="text-muted-foreground text-xs">Platform admin (UI)</p>
+            <p class="font-medium">{auth.isAdmin ? 'Yes' : 'No'}</p>
+          </div>
+        </Card.Content>
+      </Card.Root>
+
+      <Card.Root>
+        <Card.Header>
+          <Card.Title class="text-base">Tenant & session</Card.Title>
+        </Card.Header>
+        <Card.Content class="space-y-3 text-sm">
+          <div>
+            <p class="text-muted-foreground text-xs">Organization</p>
+            <p class="font-medium">
+              {#if auth.user.org}
+                <code class="text-xs">{auth.user.org}</code>
+              {:else}
+                —
+              {/if}
+            </p>
+          </div>
+          <div>
+            <p class="text-muted-foreground text-xs">Roles</p>
+            <p class="font-medium">
+              {auth.user.roles && auth.user.roles.length > 0 ? auth.user.roles.join(', ') : '—'}
+            </p>
+          </div>
+          <div>
+            <p class="text-muted-foreground text-xs">Session expires</p>
+            <p class="font-medium">{formatTokenExpiry(auth.user.expiresAt)}</p>
+          </div>
+          <div>
+            <p class="text-muted-foreground text-xs">Mode / version</p>
+            <p class="font-medium">
+              {mode || '…'}
+              {#if version}
+                <span class="text-muted-foreground"> · {version}</span>
+              {/if}
+            </p>
+          </div>
+        </Card.Content>
+      </Card.Root>
+    </div>
+  {/if}
+</div>

--- a/web-ui/src/routes/(app)/admin/organizations/+page.svelte
+++ b/web-ui/src/routes/(app)/admin/organizations/+page.svelte
@@ -297,7 +297,7 @@
   <title>Admin — reShapr</title>
 </svelte:head>
 
-<div class="p-6 space-y-6">
+<div class="space-y-6">
   <!-- Header -->
   <div class="flex items-center justify-between">
     <div>

--- a/web-ui/src/routes/(app)/admin/organizations/UsersTab.svelte
+++ b/web-ui/src/routes/(app)/admin/organizations/UsersTab.svelte
@@ -16,7 +16,7 @@
 
 <script lang="ts">
   import { onMount } from 'svelte';
-  import { Badge } from '$lib/components/ui/badge';
+  import { Badge } from '$lib/components/ui/badge/index.js';
   import { Button } from '$lib/components/ui/button/index.js';
   import { Checkbox } from '$lib/components/ui/checkbox/index.js';
   import { Input } from '$lib/components/ui/input/index.js';

--- a/web-ui/src/routes/(app)/api-tokens/+page.svelte
+++ b/web-ui/src/routes/(app)/api-tokens/+page.svelte
@@ -1,3 +1,19 @@
+<!--
+  ~ Copyright The Reshapr Authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
 <script lang="ts">
 	import { apiClient, ApiError } from '$lib/api/client.js';
 	import ApiErrorAlert from '$lib/components/ApiErrorAlert.svelte';

--- a/web-ui/src/routes/(app)/api-tokens/+page.svelte
+++ b/web-ui/src/routes/(app)/api-tokens/+page.svelte
@@ -1,0 +1,136 @@
+<script lang="ts">
+	import { apiClient, ApiError } from '$lib/api/client.js';
+	import ApiErrorAlert from '$lib/components/ApiErrorAlert.svelte';
+	import PageHeader from '$lib/components/PageHeader.svelte';
+	import * as Alert from '$lib/components/ui/alert/index.js';
+	import { Button } from '$lib/components/ui/button/index.js';
+	import * as Card from '$lib/components/ui/card/index.js';
+	import { Input } from '$lib/components/ui/input/index.js';
+	import * as Select from '$lib/components/ui/select/index.js';
+	import * as Table from '$lib/components/ui/table/index.js';
+
+	type TokenRow = { id: string; name: string; validUntil?: string };
+
+	const VALIDITY = [1, 7, 30, 90] as const;
+
+	let rows = $state<TokenRow[]>([]);
+	let error = $state<string | null>(null);
+	let createdToken = $state<string | null>(null);
+	let validityDays = $state('30');
+
+	async function load() {
+		error = null;
+		try {
+			const data = (await apiClient().listApiTokens()) as TokenRow[];
+			rows = Array.isArray(data) ? data : [];
+		} catch (e) {
+			error = e instanceof ApiError ? e.message : String(e);
+		}
+	}
+
+	$effect(() => {
+		void load();
+	});
+
+	async function onCreate(ev: SubmitEvent) {
+		ev.preventDefault();
+		createdToken = null;
+		const fd = new FormData(ev.target as HTMLFormElement);
+		const name = String(fd.get('name') || '');
+		const days = Number(validityDays || 30);
+		if (!name) return;
+		error = null;
+		try {
+			const out = (await apiClient().createApiToken({ name, validityDays: days })) as {
+				token?: string;
+			};
+			if (out.token) createdToken = out.token;
+			(ev.target as HTMLFormElement).reset();
+			validityDays = '30';
+			await load();
+		} catch (e) {
+			error = e instanceof ApiError ? e.message : String(e);
+		}
+	}
+
+	async function onDelete(tokenId: string) {
+		if (!confirm('Revoke this token?')) return;
+		error = null;
+		try {
+			await apiClient().deleteApiToken(tokenId);
+			await load();
+		} catch (e) {
+			error = e instanceof ApiError ? e.message : String(e);
+		}
+	}
+</script>
+
+<PageHeader title="API tokens">
+	{#snippet actions()}
+		<Button variant="outline" onclick={() => void load()}>Refresh</Button>
+	{/snippet}
+</PageHeader>
+
+{#if createdToken}
+	<Alert.Root class="mb-4">
+		<Alert.Title>Token (copy once)</Alert.Title>
+		<Alert.Description>
+			<code class="text-xs break-all">{createdToken}</code>
+		</Alert.Description>
+	</Alert.Root>
+{/if}
+
+{#if error}
+	<ApiErrorAlert message={error} />
+{/if}
+
+<Card.Root class="mb-6">
+	<Card.Header>
+		<Card.Title>Create</Card.Title>
+	</Card.Header>
+	<Card.Content>
+		<form class="flex flex-wrap items-end gap-3" onsubmit={onCreate}>
+			<Input name="name" placeholder="Name" class="max-w-xs" required />
+			<Select.Root type="single" bind:value={validityDays}>
+				<Select.Trigger class="w-[140px]">
+					{validityDays} day{Number(validityDays) > 1 ? 's' : ''}
+				</Select.Trigger>
+				<Select.Content>
+					{#each VALIDITY as d (d)}
+						<Select.Item value={String(d)}>{d} day{d > 1 ? 's' : ''}</Select.Item>
+					{/each}
+				</Select.Content>
+			</Select.Root>
+			<Button type="submit">Create</Button>
+		</form>
+	</Card.Content>
+</Card.Root>
+
+<div class="rounded-lg border">
+	<Table.Root>
+		<Table.Header>
+			<Table.Row>
+				<Table.Head>ID</Table.Head>
+				<Table.Head>Name</Table.Head>
+				<Table.Head>Valid until</Table.Head>
+				<Table.Head class="w-[100px]" />
+			</Table.Row>
+		</Table.Header>
+		<Table.Body>
+			{#each rows as t (t.id)}
+				<Table.Row>
+					<Table.Cell>{t.id}</Table.Cell>
+					<Table.Cell>{t.name}</Table.Cell>
+					<Table.Cell>
+						{t.validUntil ? new Date(t.validUntil).toLocaleString() : '—'}
+					</Table.Cell>
+					<Table.Cell>
+						<Button variant="destructive" size="sm" onclick={() => void onDelete(t.id)}>
+							Revoke
+						</Button>
+					</Table.Cell>
+				</Table.Row>
+			{/each}
+		</Table.Body>
+	</Table.Root>
+</div>

--- a/web-ui/src/routes/(app)/artifacts/+page.svelte
+++ b/web-ui/src/routes/(app)/artifacts/+page.svelte
@@ -1,0 +1,618 @@
+<script lang="ts">
+	import { apiClient, ApiError } from '$lib/api/client.js';
+	import ApiErrorAlert from '$lib/components/ApiErrorAlert.svelte';
+	import PageHeader from '$lib/components/PageHeader.svelte';
+	import * as Alert from '$lib/components/ui/alert/index.js';
+	import { Button } from '$lib/components/ui/button/index.js';
+	import { Checkbox } from '$lib/components/ui/checkbox/index.js';
+	import * as Collapsible from '$lib/components/ui/collapsible/index.js';
+	import * as Card from '$lib/components/ui/card/index.js';
+	import { Input } from '$lib/components/ui/input/index.js';
+	import { Label } from '$lib/components/ui/label/index.js';
+	import { Textarea } from '$lib/components/ui/textarea/index.js';
+	import { parseOperationsList } from '$lib/operationsList.js';
+
+	type Api = ReturnType<typeof apiClient>;
+
+	type ExposeOptions = {
+		backendEndpoint: string;
+		gatewayGroupId: string;
+		backendSecretId?: string;
+		genApiKey: boolean;
+		includedOperations?: string[];
+		excludedOperations?: string[];
+	};
+
+	type ExposeResult = {
+		serviceId: string;
+		serviceName: string;
+		planId: string;
+		expoId?: string;
+		planApiKey?: string;
+	};
+
+	const DEFAULT_OPEN_METEO_URL =
+		'https://raw.githubusercontent.com/open-meteo/open-meteo/refs/heads/main/openapi.yml';
+	const DEFAULT_OPEN_METEO_BACKEND = 'https://api.open-meteo.com';
+
+	let msg = $state<string | null>(null);
+	let err = $state<string | null>(null);
+	let importServiceApiKey = $state<string | null>(null);
+	let importSource = $state<'file' | 'url'>('file');
+	let genKeyImport = $state(false);
+
+	let importExposeOpen = $state(true);
+	let importOnlyOpen = $state(false);
+	let attachCustomToolsOpen = $state(false);
+	let attachPromptsOpen = $state(false);
+	let advancedAttachOpen = $state(false);
+	let specUrl = $state(DEFAULT_OPEN_METEO_URL);
+	let backendEndpointExpose = $state('');
+	let includedOperationsExpose = $state('');
+
+	$effect(() => {
+		if (importSource === 'url') {
+			backendEndpointExpose = DEFAULT_OPEN_METEO_BACKEND;
+		} else {
+			backendEndpointExpose = '';
+		}
+	});
+
+	function asImportedService(v: unknown): { id: string; name: string } | null {
+		if (!v || typeof v !== 'object') return null;
+		const o = v as Record<string, unknown>;
+		if (typeof o.id !== 'string' || typeof o.name !== 'string') return null;
+		return { id: o.id, name: o.name };
+	}
+
+	async function createPlanAndExposition(
+		c: Api,
+		imported: unknown,
+		opts: ExposeOptions
+	): Promise<ExposeResult> {
+		const service = asImportedService(imported);
+		if (!service) {
+			throw new Error('Unexpected import response: service id or name is missing.');
+		}
+
+		const planBody: Record<string, unknown> = {
+			name: `default-plan for ${service.name}`,
+			description: `Configuration plan for ${service.name} on ${opts.backendEndpoint}`,
+			serviceId: service.id,
+			backendEndpoint: opts.backendEndpoint,
+			backendSecretId: opts.backendSecretId
+		};
+		if (opts.genApiKey) planBody.apiKey = 'generate-me';
+		if (opts.includedOperations?.length) planBody.includedOperations = opts.includedOperations;
+		if (opts.excludedOperations?.length) planBody.excludedOperations = opts.excludedOperations;
+
+		const plan = (await c.createConfigurationPlan(planBody)) as { id: string; apiKey?: string };
+		const expo = (await c.createExposition({
+			configurationPlanId: plan.id,
+			gatewayGroupId: opts.gatewayGroupId
+		})) as { id?: string };
+
+		return {
+			serviceId: service.id,
+			serviceName: service.name,
+			planId: plan.id,
+			expoId: expo.id,
+			planApiKey: plan.apiKey
+		};
+	}
+
+	function clearAlerts() {
+		err = null;
+		msg = null;
+		importServiceApiKey = null;
+	}
+
+	function formatAttachSuccess(out: unknown): string {
+		if (out && typeof out === 'object') {
+			const o = out as Record<string, unknown>;
+			const name = typeof o.name === 'string' ? o.name : undefined;
+			const type = typeof o.type === 'string' ? o.type : undefined;
+			const id = typeof o.id === 'string' ? o.id : undefined;
+			const bits = ['Attach OK'];
+			if (type) bits.push(`type ${type}`);
+			if (name) bits.push(`« ${name} »`);
+			if (id) bits.push(`id ${id}`);
+			return bits.join(' — ');
+		}
+		return `Attach OK : ${JSON.stringify(out)}`;
+	}
+
+	async function onImportAndExpose(ev: SubmitEvent) {
+		ev.preventDefault();
+		const form = ev.target as HTMLFormElement;
+		clearAlerts();
+		const fd = new FormData(form);
+
+		const backendEndpoint = String(fd.get('backendEndpoint') || '').trim();
+		if (!backendEndpoint) {
+			err = 'Target backend URL (--backendEndpoint) is required.';
+			return;
+		}
+		const sn = String(fd.get('serviceNameIs') || '').trim();
+		const sv = String(fd.get('serviceVersionIs') || '').trim();
+		if ((sn && !sv) || (!sn && sv)) {
+			err = 'For GraphQL: set both serviceName and serviceVersion, or leave both empty.';
+			return;
+		}
+		const gatewayGroupId = String(fd.get('gatewayGroupId') || '').trim() || '1';
+		const backendSecretId = String(fd.get('backendSecretId') || '').trim() || undefined;
+		let includedOperations: string[] = [];
+		try {
+			includedOperations = parseOperationsList(includedOperationsExpose);
+		} catch (e) {
+			err = e instanceof Error ? e.message : String(e);
+			return;
+		}
+
+		const extra: Record<string, string> = {};
+		if (sn) extra.serviceName = sn;
+		if (sv) extra.serviceVersion = sv;
+
+		try {
+			const c = apiClient();
+			let imported: unknown;
+
+			if (importSource === 'file') {
+				const file = fd.get('serviceSpecFile') as File | null;
+				if (!file?.size) {
+					err = 'Choose a specification file (-f / --file).';
+					return;
+				}
+				imported = await c.importArtifactFile(file, extra);
+			} else {
+				const url = String(fd.get('specUrl') || '').trim();
+				if (!url) {
+					err = 'Specification URL is required (-u / --url).';
+					return;
+				}
+				const p = new URLSearchParams();
+				p.set('url', url);
+				p.set('mainArtifact', 'true');
+				const secret = String(fd.get('secretName') || '').trim();
+				if (secret) p.set('secretName', secret);
+				if (sn) p.set('serviceName', sn);
+				if (sv) p.set('serviceVersion', sv);
+				imported = await c.importArtifactUrl(p);
+			}
+
+			const out = await createPlanAndExposition(c, imported, {
+				backendEndpoint,
+				gatewayGroupId,
+				backendSecretId,
+				genApiKey: genKeyImport,
+				includedOperations: includedOperations.length ? includedOperations : undefined
+			});
+			if (out.planApiKey) importServiceApiKey = out.planApiKey;
+			const via = importSource === 'file' ? '-f' : '-u';
+			msg =
+				`Import + exposition OK (${via}, --backendEndpoint) — service "${out.serviceName}" (${out.serviceId}), plan ${out.planId}` +
+				(out.expoId ? `, exposition ${out.expoId}.` : '.');
+			form.reset();
+			genKeyImport = false;
+		} catch (e) {
+			err = e instanceof ApiError ? e.message : String(e);
+		}
+	}
+
+	async function onImportFile(ev: SubmitEvent) {
+		ev.preventDefault();
+		const form = ev.target as HTMLFormElement;
+		err = null;
+		msg = null;
+		importServiceApiKey = null;
+		const fd = new FormData(form);
+		const file = fd.get('file') as File | null;
+		if (!file?.size) {
+			err = 'Choose a file.';
+			return;
+		}
+		const sn = String(fd.get('serviceName') || '').trim();
+		const sv = String(fd.get('serviceVersion') || '').trim();
+		const extra: Record<string, string> = {};
+		if (sn) extra.serviceName = sn;
+		if (sv) extra.serviceVersion = sv;
+		try {
+			const out = await apiClient().importArtifactFile(file, extra);
+			msg = `Import OK : ${JSON.stringify(out)}`;
+			form.reset();
+		} catch (e) {
+			err = e instanceof ApiError ? e.message : String(e);
+		}
+	}
+
+	async function onImportUrl(ev: SubmitEvent) {
+		ev.preventDefault();
+		const form = ev.target as HTMLFormElement;
+		err = null;
+		msg = null;
+		importServiceApiKey = null;
+		const fd = new FormData(form);
+		const url = String(fd.get('url') || '');
+		if (!url) {
+			err = 'URL is required.';
+			return;
+		}
+		const p = new URLSearchParams();
+		p.set('url', url);
+		p.set('mainArtifact', 'true');
+		const secret = String(fd.get('secretName') || '');
+		if (secret) p.set('secretName', secret);
+		const sn = String(fd.get('serviceName') || '');
+		const sv = String(fd.get('serviceVersion') || '');
+		if (sn) p.set('serviceName', sn);
+		if (sv) p.set('serviceVersion', sv);
+		try {
+			const out = await apiClient().importArtifactUrl(p);
+			msg = `Import URL OK : ${JSON.stringify(out)}`;
+			form.reset();
+		} catch (e) {
+			err = e instanceof ApiError ? e.message : String(e);
+		}
+	}
+
+	async function onAttachFile(ev: SubmitEvent) {
+		ev.preventDefault();
+		const form = ev.target as HTMLFormElement;
+		err = null;
+		msg = null;
+		importServiceApiKey = null;
+		const fd = new FormData(form);
+		const file = fd.get('afile') as File | null;
+		if (!file?.size) {
+			err = 'Choose a file.';
+			return;
+		}
+		try {
+			const out = await apiClient().attachArtifactFile(file);
+			msg = formatAttachSuccess(out);
+			form.reset();
+		} catch (e) {
+			err = e instanceof ApiError ? e.message : String(e);
+		}
+	}
+
+	async function onAttachUrl(ev: SubmitEvent) {
+		ev.preventDefault();
+		const form = ev.target as HTMLFormElement;
+		err = null;
+		msg = null;
+		importServiceApiKey = null;
+		const fd = new FormData(form);
+		const url = String(fd.get('aurl') || '');
+		const secret = String(fd.get('asecret') || '');
+		if (!url) {
+			err = 'URL is required.';
+			return;
+		}
+		try {
+			const out = await apiClient().attachArtifactUrl(url, secret || undefined);
+			msg = formatAttachSuccess(out);
+			form.reset();
+		} catch (e) {
+			err = e instanceof ApiError ? e.message : String(e);
+		}
+	}
+</script>
+
+<PageHeader title="Artifacts" />
+
+<Alert.Root class="mb-4">
+	<Alert.Title>MCP server creation (recommended order)</Alert.Title>
+	<Alert.Description class="space-y-2 text-sm">
+		<ol class="list-decimal space-y-1 pl-5">
+			<li><strong>Import + expose</strong> — spec, backend URL, optional <code class="text-xs">--io</code>.</li>
+			<li><strong>Import only</strong> — if you split plan/exposition on <a href="/plans/new" class="text-primary hover:underline">Plans</a>.</li>
+			<li><strong>Custom tools</strong> — YAML <code class="text-xs">kind: CustomTools</code>.</li>
+			<li><strong>MCP prompts</strong> — YAML <code class="text-xs">kind: Prompts</code>.</li>
+			<li>
+				<strong>Verify</strong> —
+				<a href="/mcp-custom-tools" class="text-primary hover:underline">MCP custom tools</a>,
+				<a href="/mcp-prompts" class="text-primary hover:underline">MCP prompts</a>.
+			</li>
+		</ol>
+		<p class="text-muted-foreground">
+			Full guide: <code class="text-xs">docs/MCP_SERVER_SETUP.md</code> in this repository.
+		</p>
+	</Alert.Description>
+</Alert.Root>
+
+{#if err}
+	<ApiErrorAlert message={err} />
+{/if}
+{#if msg}
+	<Alert.Root class="mb-4 border-green-600/30">
+		<Alert.Title>Success</Alert.Title>
+		<Alert.Description>{msg}</Alert.Description>
+	</Alert.Root>
+{/if}
+{#if importServiceApiKey}
+	<Alert.Root class="mb-4">
+		<Alert.Title>Plan API key (copy once)</Alert.Title>
+		<Alert.Description>
+			<code class="text-xs break-all">{importServiceApiKey}</code>
+			<p class="text-muted-foreground mt-2 text-xs">Save it now; it will not be shown again.</p>
+		</Alert.Description>
+	</Alert.Root>
+{/if}
+
+<Collapsible.Root bind:open={importExposeOpen} class="mb-4">
+	<Card.Root>
+		<Collapsible.Trigger class="w-full text-left">
+			<Card.Header>
+				<Card.Title class="text-base">1. Import + expose (spec, plan, exposition)</Card.Title>
+				<Card.Description>
+					Like <code class="text-xs">reshapr import -f|-u … --backendEndpoint …</code> then plan + exposition.
+					Optional <code class="text-xs">--io</code> below. Needs a
+					<a href="/gateway-groups" class="text-primary hover:underline">gateway group</a>.
+				</Card.Description>
+			</Card.Header>
+		</Collapsible.Trigger>
+		<Collapsible.Content>
+			<Card.Content>
+				<form class="space-y-4" onsubmit={onImportAndExpose}>
+					<div class="space-y-2">
+						<span class="text-sm font-medium">Specification source</span>
+						<div class="flex flex-wrap gap-4">
+							<label class="flex items-center gap-2 text-sm">
+								<input
+									type="radio"
+									name="importSourceUi"
+									checked={importSource === 'file'}
+									onchange={() => (importSource = 'file')}
+								/>
+								File (<code class="text-xs">-f</code>)
+							</label>
+							<label class="flex items-center gap-2 text-sm">
+								<input
+									type="radio"
+									name="importSourceUi"
+									checked={importSource === 'url'}
+									onchange={() => (importSource = 'url')}
+								/>
+								URL (<code class="text-xs">-u</code>)
+							</label>
+						</div>
+					</div>
+
+					{#if importSource === 'file'}
+						<div class="space-y-2">
+							<Label for="serviceSpecFile">Specification file</Label>
+							<Input id="serviceSpecFile" type="file" name="serviceSpecFile" />
+						</div>
+					{:else}
+						<div class="space-y-2">
+							<Label for="specUrl">Specification URL</Label>
+							<Input
+								id="specUrl"
+								name="specUrl"
+								class="w-full"
+								bind:value={specUrl}
+								placeholder="https://…"
+								autocomplete="off"
+							/>
+						</div>
+						<div class="space-y-2">
+							<Label for="secretName">Secret to fetch the spec (optional)</Label>
+							<Input id="secretName" name="secretName" autocomplete="off" />
+						</div>
+					{/if}
+
+					{#key importSource}
+						<div class="space-y-2">
+							<Label for="backendEndpoint">Backend endpoint (<code class="text-xs">--backendEndpoint</code>)</Label>
+							<Input
+								id="backendEndpoint"
+								name="backendEndpoint"
+								class="w-full"
+								placeholder="https://…"
+								required
+								bind:value={backendEndpointExpose}
+								autocomplete="off"
+							/>
+						</div>
+					{/key}
+					<div class="space-y-2">
+						<Label for="gatewayGroupId">Gateway group ID (default: 1)</Label>
+						<Input id="gatewayGroupId" name="gatewayGroupId" placeholder="1" value="1" autocomplete="off" />
+					</div>
+					<div class="space-y-2">
+						<Label for="backendSecretId">Backend secret ID (optional)</Label>
+						<Input id="backendSecretId" name="backendSecretId" autocomplete="off" />
+					</div>
+					<div class="space-y-2">
+						<Label for="serviceNameIs">serviceName (GraphQL, optional)</Label>
+						<Input id="serviceNameIs" name="serviceNameIs" autocomplete="off" />
+					</div>
+					<div class="space-y-2">
+						<Label for="serviceVersionIs">serviceVersion (GraphQL, optional)</Label>
+						<Input id="serviceVersionIs" name="serviceVersionIs" autocomplete="off" />
+					</div>
+					<div class="space-y-2">
+						<Label for="includedOperationsExpose">Included operations (<code class="text-xs">--io</code>, optional)</Label>
+						<Textarea
+							id="includedOperationsExpose"
+							bind:value={includedOperationsExpose}
+							rows={3}
+							class="font-mono text-xs"
+							placeholder={'POST /tests/{testId}/start\nGET /masters'}
+						/>
+					</div>
+					<div class="flex items-center gap-2">
+						<Checkbox id="apiKeyIs" bind:checked={genKeyImport} />
+						<Label for="apiKeyIs">Generate an API key on the plan</Label>
+					</div>
+					<Button type="submit">Import and expose</Button>
+				</form>
+			</Card.Content>
+		</Collapsible.Content>
+	</Card.Root>
+</Collapsible.Root>
+
+<Collapsible.Root bind:open={importOnlyOpen} class="mb-4">
+	<Card.Root>
+		<Collapsible.Trigger class="w-full text-left">
+			<Card.Header>
+				<Card.Title class="text-base">2. Import specification only (split workflow)</Card.Title>
+				<Card.Description>
+					<code class="text-xs">POST /api/v1/artifacts</code> without plan or exposition — then
+					<a href="/plans/new" class="text-primary hover:underline">create a plan</a> with
+					<code class="text-xs">--io</code> and an exposition.
+				</Card.Description>
+			</Card.Header>
+		</Collapsible.Trigger>
+		<Collapsible.Content>
+			<Card.Content class="space-y-6">
+				<form class="flex flex-wrap items-end gap-3" onsubmit={onImportFile}>
+					<Input type="file" name="file" required />
+					<Input name="serviceName" placeholder="serviceName (GraphQL)" />
+					<Input name="serviceVersion" placeholder="serviceVersion" />
+					<Button type="submit" variant="secondary">Import file</Button>
+				</form>
+				<form class="flex flex-wrap items-end gap-3 border-t pt-4" onsubmit={onImportUrl}>
+					<Input name="url" placeholder="https://…" class="min-w-[200px] flex-1" required />
+					<Input name="secretName" placeholder="secretName (optional)" />
+					<Input name="serviceName" placeholder="serviceName" />
+					<Input name="serviceVersion" placeholder="serviceVersion" />
+					<Button type="submit" variant="secondary">Import URL</Button>
+				</form>
+			</Card.Content>
+		</Collapsible.Content>
+	</Card.Root>
+</Collapsible.Root>
+
+<Collapsible.Root bind:open={attachCustomToolsOpen} class="mb-4">
+	<Card.Root>
+		<Collapsible.Trigger class="w-full text-left">
+			<Card.Header>
+				<Card.Title class="text-base">3. Attach custom tools (YAML)</Card.Title>
+				<Card.Description>
+					Like <code class="text-xs">reshapr attach -f custom-tools.yaml</code> —
+					<code class="text-xs">POST /api/v1/artifacts/attach</code>. Document
+					<code class="text-xs">kind: CustomTools</code> (schema
+					<code class="text-xs">CustomTools-v1alpha1</code>) bound to an existing service. Example in the
+					<a
+						href="https://github.com/reshaprio/reshapr/blob/main/dev/github-api-custom-tools.yaml"
+						target="_blank"
+						rel="noreferrer"
+						class="text-primary hover:underline"
+					>reshapr repo</a>.
+				</Card.Description>
+			</Card.Header>
+		</Collapsible.Trigger>
+		<Collapsible.Content>
+			<Card.Content class="space-y-4">
+				<form class="flex flex-wrap items-end gap-3" onsubmit={onAttachFile}>
+					<div class="min-w-[200px] flex-1 space-y-2">
+						<Label for="customToolsFile">Custom tools file</Label>
+						<Input id="customToolsFile" type="file" name="afile" accept=".yaml,.yml,.json" required />
+					</div>
+					<Button type="submit">Attach file</Button>
+				</form>
+				<form class="flex flex-wrap items-end gap-3 border-t pt-4" onsubmit={onAttachUrl}>
+					<div class="min-w-[200px] flex-1 space-y-2">
+						<Label for="customToolsUrl">Or URL</Label>
+						<Input id="customToolsUrl" name="aurl" placeholder="https://…" class="w-full" required />
+					</div>
+					<div class="space-y-2">
+						<Label for="customToolsSecret">Secret (optional)</Label>
+						<Input id="customToolsSecret" name="asecret" placeholder="secretName" />
+					</div>
+					<Button type="submit" variant="secondary">Attach URL</Button>
+				</form>
+			</Card.Content>
+		</Collapsible.Content>
+	</Card.Root>
+</Collapsible.Root>
+
+<Collapsible.Root bind:open={attachPromptsOpen} class="mb-4">
+	<Card.Root>
+		<Collapsible.Trigger class="w-full text-left">
+			<Card.Header>
+				<Card.Title class="text-base">4. Attach MCP prompts (YAML)</Card.Title>
+				<Card.Description>
+					Same endpoint as custom tools: <code class="text-xs">reshapr attach -f prompts.yaml</code> →
+					<code class="text-xs">POST /api/v1/artifacts/attach</code>. Document
+					<code class="text-xs">kind: Prompts</code> (<code class="text-xs">Prompts-v1alpha1</code>) with
+					<code class="text-xs">service.name</code> / <code class="text-xs">service.version</code> matching the
+					imported service. Example:
+					<a
+						href="https://github.com/reshaprio/reshapr/blob/main/dev/apipastry-prompts.yaml"
+						target="_blank"
+						rel="noreferrer"
+						class="text-primary hover:underline"
+					>apipastry-prompts.yaml</a>.
+				</Card.Description>
+			</Card.Header>
+		</Collapsible.Trigger>
+		<Collapsible.Content>
+			<Card.Content class="space-y-4">
+				<p class="text-muted-foreground text-xs">
+					Minimal shape: <code class="text-xs">apiVersion: reshapr.io/v1alpha1</code>,
+					<code class="text-xs">kind: Prompts</code>, <code class="text-xs">service</code>,
+					<code class="text-xs">prompts:</code> map of prompt definitions. Verify on <a href="/mcp-prompts" class="text-primary hover:underline">MCP prompts</a> (control-plane artifact, no CORS).
+				</p>
+				<form class="flex flex-wrap items-end gap-3" onsubmit={onAttachFile}>
+					<div class="min-w-[200px] flex-1 space-y-2">
+						<Label for="promptsFile">Prompts file</Label>
+						<Input id="promptsFile" type="file" name="afile" accept=".yaml,.yml" required />
+					</div>
+					<Button type="submit">Attach file</Button>
+				</form>
+				<form class="flex flex-wrap items-end gap-3 border-t pt-4" onsubmit={onAttachUrl}>
+					<div class="min-w-[200px] flex-1 space-y-2">
+						<Label for="promptsUrl">Or URL</Label>
+						<Input id="promptsUrl" name="aurl" placeholder="https://…" class="w-full" required />
+					</div>
+					<div class="space-y-2">
+						<Label for="promptsSecret">Secret (optional)</Label>
+						<Input id="promptsSecret" name="asecret" placeholder="secretName" />
+					</div>
+					<Button type="submit" variant="secondary">Attach URL</Button>
+				</form>
+			</Card.Content>
+		</Collapsible.Content>
+	</Card.Root>
+</Collapsible.Root>
+
+<Card.Root class="mb-4">
+	<Card.Header>
+		<Card.Title class="text-base">5. Verify MCP</Card.Title>
+		<Card.Description>After steps 1–4, confirm tools and prompts on the exposition.</Card.Description>
+	</Card.Header>
+	<Card.Content class="flex flex-wrap gap-2">
+		<Button variant="outline" href="/services">Services</Button>
+		<Button variant="outline" href="/plans">Plans</Button>
+		<Button variant="outline" href="/expositions">Expositions</Button>
+		<Button variant="outline" href="/mcp-custom-tools">MCP custom tools</Button>
+		<Button variant="outline" href="/mcp-prompts">MCP prompts</Button>
+	</Card.Content>
+</Card.Root>
+
+<Collapsible.Root bind:open={advancedAttachOpen} class="mb-4">
+	<Card.Root>
+		<Collapsible.Trigger class="w-full text-left">
+			<Card.Header>
+				<Card.Title class="text-base">Advanced — generic attach</Card.Title>
+				<Card.Description>POST /api/v1/artifacts/attach for any artifact type (file or URL).</Card.Description>
+			</Card.Header>
+		</Collapsible.Trigger>
+		<Collapsible.Content>
+			<Card.Content class="space-y-4">
+				<form class="flex flex-wrap items-end gap-3" onsubmit={onAttachFile}>
+					<Input type="file" name="afile" required />
+					<Button type="submit" variant="secondary">Attach file</Button>
+				</form>
+				<form class="flex flex-wrap items-end gap-3 border-t pt-4" onsubmit={onAttachUrl}>
+					<Input name="aurl" placeholder="https://…" class="min-w-[200px] flex-1" required />
+					<Input name="asecret" placeholder="secretName (optional)" />
+					<Button type="submit" variant="secondary">Attach URL</Button>
+				</form>
+			</Card.Content>
+		</Collapsible.Content>
+	</Card.Root>
+</Collapsible.Root>

--- a/web-ui/src/routes/(app)/artifacts/+page.svelte
+++ b/web-ui/src/routes/(app)/artifacts/+page.svelte
@@ -1,3 +1,19 @@
+<!--
+  ~ Copyright The Reshapr Authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
 <script lang="ts">
 	import { apiClient, ApiError } from '$lib/api/client.js';
 	import ApiErrorAlert from '$lib/components/ApiErrorAlert.svelte';

--- a/web-ui/src/routes/(app)/expositions/+page.svelte
+++ b/web-ui/src/routes/(app)/expositions/+page.svelte
@@ -1,3 +1,19 @@
+<!--
+  ~ Copyright The Reshapr Authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
 <script lang="ts">
 	import { apiClient, ApiError } from '$lib/api/client.js';
 	import ApiErrorAlert from '$lib/components/ApiErrorAlert.svelte';

--- a/web-ui/src/routes/(app)/expositions/+page.svelte
+++ b/web-ui/src/routes/(app)/expositions/+page.svelte
@@ -1,0 +1,217 @@
+<script lang="ts">
+	import { apiClient, ApiError } from '$lib/api/client.js';
+	import ApiErrorAlert from '$lib/components/ApiErrorAlert.svelte';
+	import PageHeader from '$lib/components/PageHeader.svelte';
+	import { Button } from '$lib/components/ui/button/index.js';
+	import * as Card from '$lib/components/ui/card/index.js';
+	import { Input } from '$lib/components/ui/input/index.js';
+	import { Label } from '$lib/components/ui/label/index.js';
+	import * as Table from '$lib/components/ui/table/index.js';
+	import { formatRelativeAge } from '$lib/utils/relativeAge.js';
+
+	type ExpoRow = {
+		id: string;
+		service: string;
+		backend: string;
+		endpoints: string;
+		age: string;
+	};
+
+	let mode = $state<'active' | 'all'>('active');
+	let rows = $state<ExpoRow[]>([]);
+	let error = $state<string | null>(null);
+	let planId = $state('1');
+	let ggId = $state('1');
+
+	function serviceLabel(service: unknown): string {
+		if (!service || typeof service !== 'object') return '—';
+		const s = service as Record<string, unknown>;
+		const name = typeof s.name === 'string' ? s.name : '';
+		const version = typeof s.version === 'string' ? s.version : '';
+		if (name && version) return `${name}:${version}`;
+		if (name) return name;
+		return '—';
+	}
+
+	function backendUrl(configurationPlan: unknown): string {
+		if (!configurationPlan || typeof configurationPlan !== 'object') return '—';
+		const c = configurationPlan as Record<string, unknown>;
+		return typeof c.backendEndpoint === 'string' ? c.backendEndpoint : '—';
+	}
+
+	function endpointsLabel(raw: Record<string, unknown>): string {
+		const cp = raw.configurationPlan;
+		if (cp && typeof cp === 'object') {
+			const c = cp as Record<string, unknown>;
+			const inc = c.includedOperations;
+			if (Array.isArray(inc)) return String(inc.length);
+		}
+		const gws = raw.gateways;
+		if (Array.isArray(gws)) {
+			let n = 0;
+			for (const g of gws) {
+				if (g && typeof g === 'object') {
+					const fq = (g as Record<string, unknown>).fqdns;
+					if (Array.isArray(fq)) n += fq.length;
+				}
+			}
+			if (n > 0) return String(n);
+		}
+		return '—';
+	}
+
+	function toExpoRow(raw: unknown): ExpoRow | null {
+		if (!raw || typeof raw !== 'object') return null;
+		const o = raw as Record<string, unknown>;
+		if (typeof o.id !== 'string') return null;
+		const created =
+			typeof o.createdOn === 'string'
+				? o.createdOn
+				: typeof o.created === 'string'
+					? o.created
+					: undefined;
+		return {
+			id: o.id,
+			service: serviceLabel(o.service),
+			backend: backendUrl(o.configurationPlan),
+			endpoints: endpointsLabel(o),
+			age: formatRelativeAge(created)
+		};
+	}
+
+	async function load() {
+		error = null;
+		try {
+			const data =
+				mode === 'active'
+					? ((await apiClient().listExpositionsActive()) as unknown[])
+					: ((await apiClient().listExpositionsAll()) as unknown[]);
+			const list = Array.isArray(data) ? data : [];
+			rows = list.map(toExpoRow).filter((r): r is ExpoRow => r != null);
+		} catch (e) {
+			error = e instanceof ApiError ? e.message : String(e);
+		}
+	}
+
+	$effect(() => {
+		mode;
+		void load();
+	});
+
+	async function onCreate(ev: SubmitEvent) {
+		ev.preventDefault();
+		error = null;
+		try {
+			await apiClient().createExposition({
+				configurationPlanId: planId.trim(),
+				gatewayGroupId: ggId.trim()
+			});
+			await load();
+		} catch (e) {
+			error = e instanceof ApiError ? e.message : String(e);
+		}
+	}
+</script>
+
+<PageHeader title="Expositions">
+	{#snippet actions()}
+		<div class="flex flex-wrap items-center gap-4">
+			<label class="flex items-center gap-2 text-sm">
+				<input type="radio" name="m" checked={mode === 'active'} onchange={() => (mode = 'active')} />
+				Active
+			</label>
+			<label class="flex items-center gap-2 text-sm">
+				<input type="radio" name="m" checked={mode === 'all'} onchange={() => (mode = 'all')} />
+				All
+			</label>
+			<Button variant="outline" onclick={() => void load()}>Refresh</Button>
+		</div>
+	{/snippet}
+</PageHeader>
+
+<Card.Root class="mb-6">
+	<Card.Header>
+		<Card.Title>Create exposition</Card.Title>
+		<Card.Description>
+			The client sends <code class="text-xs">POST /api/v1/expositions</code> with a JSON body that only
+			includes two required properties:
+		</Card.Description>
+	</Card.Header>
+	<Card.Content class="space-y-4">
+		<ul class="text-muted-foreground list-inside list-disc text-sm">
+			<li>
+				<code class="text-xs">configurationPlanId</code> — id of the configuration plan (see
+				<a href="/plans" class="text-primary hover:underline">Plans</a>).
+			</li>
+			<li>
+				<code class="text-xs">gatewayGroupId</code> — id of the gateway group (see
+				<a href="/gateway-groups" class="text-primary hover:underline">Gateway groups</a>).
+			</li>
+		</ul>
+		<p class="text-muted-foreground text-sm">
+			Other server-side DTO fields are not entered here: the control plane sets them on create.
+		</p>
+		<form class="space-y-4" onsubmit={onCreate}>
+			<div class="space-y-2">
+				<Label for="expo-configurationPlanId"><code class="text-xs">configurationPlanId</code></Label>
+				<Input
+					id="expo-configurationPlanId"
+					class="w-full"
+					bind:value={planId}
+					placeholder="Plan UUID or id"
+					autocomplete="off"
+					spellcheck={false}
+				/>
+			</div>
+			<div class="space-y-2">
+				<Label for="expo-gatewayGroupId"><code class="text-xs">gatewayGroupId</code></Label>
+				<Input
+					id="expo-gatewayGroupId"
+					class="w-full"
+					bind:value={ggId}
+					placeholder="Gateway group UUID or id"
+					autocomplete="off"
+					spellcheck={false}
+				/>
+			</div>
+			<Button type="submit">Create</Button>
+		</form>
+	</Card.Content>
+</Card.Root>
+
+{#if error}
+	<ApiErrorAlert message={error} />
+{/if}
+
+<div class="rounded-lg border">
+	<Table.Root>
+		<Table.Header>
+			<Table.Row>
+				<Table.Head>ID</Table.Head>
+				<Table.Head>SERVICE</Table.Head>
+				<Table.Head>BACKEND</Table.Head>
+				<Table.Head>ENDPOINTS</Table.Head>
+				<Table.Head>AGE</Table.Head>
+				<Table.Head class="w-[100px]" />
+			</Table.Row>
+		</Table.Header>
+		<Table.Body>
+			{#each rows as x (x.id)}
+				<Table.Row>
+					<Table.Cell><code class="text-xs">{x.id}</code></Table.Cell>
+					<Table.Cell class="max-w-[200px] truncate" title={x.service}>{x.service}</Table.Cell>
+					<Table.Cell class="max-w-[200px] truncate" title={x.backend}>{x.backend}</Table.Cell>
+					<Table.Cell>{x.endpoints}</Table.Cell>
+					<Table.Cell>{x.age}</Table.Cell>
+					<Table.Cell>
+						<Button variant="outline" size="sm" href="/expositions/{x.id}">Details</Button>
+					</Table.Cell>
+				</Table.Row>
+			{/each}
+		</Table.Body>
+	</Table.Root>
+</div>
+
+{#if rows.length === 0 && !error}
+	<p class="text-muted-foreground mt-4 text-sm">No expositions.</p>
+{/if}

--- a/web-ui/src/routes/(app)/expositions/[id]/+page.svelte
+++ b/web-ui/src/routes/(app)/expositions/[id]/+page.svelte
@@ -1,3 +1,19 @@
+<!--
+  ~ Copyright The Reshapr Authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
 <script lang="ts">
 	import { page } from '$app/state';
 	import { goto } from '$app/navigation';

--- a/web-ui/src/routes/(app)/expositions/[id]/+page.svelte
+++ b/web-ui/src/routes/(app)/expositions/[id]/+page.svelte
@@ -1,0 +1,95 @@
+<script lang="ts">
+	import { page } from '$app/state';
+	import { goto } from '$app/navigation';
+	import { apiClient, ApiError } from '$lib/api/client.js';
+	import ApiErrorAlert from '$lib/components/ApiErrorAlert.svelte';
+	import JsonBlock from '$lib/components/JsonBlock.svelte';
+	import { Button } from '$lib/components/ui/button/index.js';
+
+	const id = $derived(page.params.id);
+
+	let detail = $state<unknown>(null);
+	let active = $state<unknown>(null);
+	let error = $state<string | null>(null);
+	let detailLoading = $state(true);
+	let activeLoading = $state(true);
+
+	$effect(() => {
+		const expoId = id;
+		if (!expoId) return;
+		let cancelled = false;
+		detailLoading = true;
+		activeLoading = true;
+		(async () => {
+			error = null;
+			try {
+				const d = await apiClient().getExposition(expoId);
+				if (!cancelled) {
+					detail = d;
+					detailLoading = false;
+				}
+				try {
+					const a = await apiClient().getActiveExposition(expoId);
+					if (!cancelled) {
+						active = a;
+						activeLoading = false;
+					}
+				} catch (e) {
+					if (e instanceof ApiError && e.status === 404) {
+						if (!cancelled) {
+							active = null;
+							activeLoading = false;
+						}
+					} else if (!cancelled) {
+						error = e instanceof ApiError ? e.message : String(e);
+						activeLoading = false;
+					}
+				}
+			} catch (e) {
+				if (!cancelled) {
+					error = e instanceof ApiError ? e.message : String(e);
+					detailLoading = false;
+					activeLoading = false;
+				}
+			}
+		})();
+		return () => {
+			cancelled = true;
+		};
+	});
+
+	async function onDelete() {
+		if (!id || !confirm('Delete this exposition?')) return;
+		try {
+			await apiClient().deleteExposition(id);
+			goto('/expositions');
+		} catch (e) {
+			error = e instanceof ApiError ? e.message : String(e);
+		}
+	}
+</script>
+
+<p class="mb-4">
+	<a href="/expositions" class="text-primary text-sm hover:underline">← Expositions</a>
+</p>
+
+<div class="mb-6 flex flex-wrap items-center justify-between gap-4">
+	<h2 class="text-xl font-semibold tracking-tight">Exposition {id}</h2>
+	<Button variant="destructive" onclick={() => void onDelete()}>Delete</Button>
+</div>
+
+{#if error}
+	<ApiErrorAlert message={error} />
+{/if}
+
+<h3 class="mb-2 text-lg font-medium">Details</h3>
+<JsonBlock value={detail} loading={detailLoading} />
+
+<h3 class="mb-2 mt-6 text-lg font-medium">Active (endpoints)</h3>
+{#if active}
+	<JsonBlock value={active} />
+{:else if !activeLoading}
+	<p class="text-muted-foreground text-sm">No active exposition (404) or not ready yet.</p>
+{:else}
+	<JsonBlock value={null} loading={true} />
+{/if}

--- a/web-ui/src/routes/(app)/expositions/[id]/+page.ts
+++ b/web-ui/src/routes/(app)/expositions/[id]/+page.ts
@@ -1,0 +1,1 @@
+export const prerender = false;

--- a/web-ui/src/routes/(app)/expositions/[id]/+page.ts
+++ b/web-ui/src/routes/(app)/expositions/[id]/+page.ts
@@ -1,1 +1,17 @@
+/*
+ * Copyright The Reshapr Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 export const prerender = false;

--- a/web-ui/src/routes/(app)/gateway-groups/+page.svelte
+++ b/web-ui/src/routes/(app)/gateway-groups/+page.svelte
@@ -1,3 +1,19 @@
+<!--
+  ~ Copyright The Reshapr Authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
 <script lang="ts">
 	import { apiClient, ApiError } from '$lib/api/client.js';
 	import ApiErrorAlert from '$lib/components/ApiErrorAlert.svelte';

--- a/web-ui/src/routes/(app)/gateway-groups/+page.svelte
+++ b/web-ui/src/routes/(app)/gateway-groups/+page.svelte
@@ -1,0 +1,119 @@
+<script lang="ts">
+	import { apiClient, ApiError } from '$lib/api/client.js';
+	import ApiErrorAlert from '$lib/components/ApiErrorAlert.svelte';
+	import PageHeader from '$lib/components/PageHeader.svelte';
+	import { Button } from '$lib/components/ui/button/index.js';
+	import * as Card from '$lib/components/ui/card/index.js';
+	import { Input } from '$lib/components/ui/input/index.js';
+	import * as Table from '$lib/components/ui/table/index.js';
+	import { Textarea } from '$lib/components/ui/textarea/index.js';
+
+	type Gg = { id: string; name: string; organizationId?: string; labels?: Record<string, string> };
+
+	let rows = $state<Gg[]>([]);
+	let error = $state<string | null>(null);
+
+	async function load() {
+		error = null;
+		try {
+			const data = (await apiClient().listGatewayGroups()) as Gg[];
+			rows = Array.isArray(data) ? data : [];
+		} catch (e) {
+			error = e instanceof ApiError ? e.message : String(e);
+		}
+	}
+
+	$effect(() => {
+		void load();
+	});
+
+	async function onCreate(ev: SubmitEvent) {
+		ev.preventDefault();
+		const form = ev.target as HTMLFormElement;
+		const fd = new FormData(form);
+		const name = String(fd.get('name') || '');
+		let labels: Record<string, string> = {};
+		const lj = String(fd.get('labels') || '').trim();
+		if (lj) {
+			try {
+				labels = JSON.parse(lj) as Record<string, string>;
+			} catch {
+				error = 'Labels: invalid JSON';
+				return;
+			}
+		}
+		error = null;
+		try {
+			await apiClient().createGatewayGroup({ name, labels });
+			form.reset();
+			await load();
+		} catch (e) {
+			error = e instanceof ApiError ? e.message : String(e);
+		}
+	}
+
+	async function onDelete(id: string) {
+		if (!confirm(`Delete group ${id}?`)) return;
+		error = null;
+		try {
+			await apiClient().deleteGatewayGroup(id);
+			await load();
+		} catch (e) {
+			error = e instanceof ApiError ? e.message : String(e);
+		}
+	}
+</script>
+
+<PageHeader title="Gateway groups">
+	{#snippet actions()}
+		<Button variant="outline" onclick={() => void load()}>Refresh</Button>
+	{/snippet}
+</PageHeader>
+
+{#if error}
+	<ApiErrorAlert message={error} />
+{/if}
+
+<Card.Root class="mb-6">
+	<Card.Header>
+		<Card.Title>New group</Card.Title>
+	</Card.Header>
+	<Card.Content>
+		<form class="space-y-4" onsubmit={onCreate}>
+			<Input name="name" placeholder="Name" required />
+			<Textarea name="labels" rows={3} placeholder={'Labels JSON e.g. {"env":"dev"}'} />
+			<Button type="submit">Create</Button>
+		</form>
+	</Card.Content>
+</Card.Root>
+
+<div class="rounded-lg border">
+	<Table.Root>
+		<Table.Header>
+			<Table.Row>
+				<Table.Head>ID</Table.Head>
+				<Table.Head>Org</Table.Head>
+				<Table.Head>Name</Table.Head>
+				<Table.Head>Labels</Table.Head>
+				<Table.Head class="w-[100px]" />
+			</Table.Row>
+		</Table.Header>
+		<Table.Body>
+			{#each rows as g (g.id)}
+				<Table.Row>
+					<Table.Cell>{g.id}</Table.Cell>
+					<Table.Cell>{g.organizationId}</Table.Cell>
+					<Table.Cell>{g.name}</Table.Cell>
+					<Table.Cell>
+						<code class="text-xs">{JSON.stringify(g.labels ?? {})}</code>
+					</Table.Cell>
+					<Table.Cell>
+						<Button variant="destructive" size="sm" onclick={() => void onDelete(g.id)}>
+							Delete
+						</Button>
+					</Table.Cell>
+				</Table.Row>
+			{/each}
+		</Table.Body>
+	</Table.Root>
+</div>

--- a/web-ui/src/routes/(app)/mcp-custom-tools/+page.svelte
+++ b/web-ui/src/routes/(app)/mcp-custom-tools/+page.svelte
@@ -1,0 +1,289 @@
+<script lang="ts">
+	import { apiClient, ApiError } from '$lib/api/client.js';
+	import ApiErrorAlert from '$lib/components/ApiErrorAlert.svelte';
+	import PageHeader from '$lib/components/PageHeader.svelte';
+	import ScrollableCode from '$lib/components/ScrollableCode.svelte';
+	import { Badge } from '$lib/components/ui/badge/index.js';
+	import { Button } from '$lib/components/ui/button/index.js';
+	import * as Card from '$lib/components/ui/card/index.js';
+	import * as Collapsible from '$lib/components/ui/collapsible/index.js';
+	import { Input } from '$lib/components/ui/input/index.js';
+	import { Label } from '$lib/components/ui/label/index.js';
+	import * as Table from '$lib/components/ui/table/index.js';
+	import { Textarea } from '$lib/components/ui/textarea/index.js';
+	import {
+		resolveMcpCustomToolsFromUrl,
+		type McpCustomToolsResolution
+	} from '$lib/mcpCustomTools.js';
+	import { listMcpEndpointUrls, type McpUrlListItem } from '$lib/mcpEndpointUrls.js';
+
+	let mcpUrl = $state('');
+	let urlMode = $state<'active' | 'all'>('active');
+	let urlList = $state<McpUrlListItem[]>([]);
+	let urlListLoading = $state(false);
+	let result = $state<McpCustomToolsResolution | null>(null);
+	let error = $state<string | null>(null);
+	let loading = $state(false);
+	let rawJsonOpen = $state(false);
+	let yamlOpen = $state(true);
+
+	const tools = $derived(result?.tools ?? []);
+
+	async function runResolve(url: string) {
+		const trimmed = url.trim();
+		if (!trimmed) {
+			error = 'MCP URL is empty';
+			return;
+		}
+		mcpUrl = trimmed;
+		error = null;
+		result = null;
+		loading = true;
+		try {
+			const c = apiClient();
+			const payload = await resolveMcpCustomToolsFromUrl(trimmed, {
+				listServicesPage: (page, size) => c.listServicesPage(page, size),
+				listExpositionsActive: () => c.listExpositionsActive(),
+				listExpositionsAll: () => c.listExpositionsAll(),
+				getExposition: (id) => c.getExposition(id),
+				listArtifactsByService: (serviceId) => c.listArtifactsByService(serviceId),
+				getService: (id) => c.getService(id)
+			});
+			result = payload;
+			yamlOpen = Boolean(payload.artifactYaml);
+		} catch (e) {
+			error = e instanceof ApiError ? e.message : String(e);
+		} finally {
+			loading = false;
+		}
+	}
+
+	function onSubmit(ev: SubmitEvent) {
+		ev.preventDefault();
+		void runResolve(mcpUrl);
+	}
+
+	async function loadMcpUrls() {
+		error = null;
+		urlListLoading = true;
+		urlList = [];
+		try {
+			const c = apiClient();
+			const items = await listMcpEndpointUrls(urlMode, {
+				listExpositionsActive: () => c.listExpositionsActive(),
+				listExpositionsAll: () => c.listExpositionsAll(),
+				getActiveExpositionOrNull: (id) => c.getActiveExpositionOrNull(id)
+			});
+			urlList = items;
+		} catch (e) {
+			error = e instanceof ApiError ? e.message : String(e);
+		} finally {
+			urlListLoading = false;
+		}
+	}
+
+	function gatewayLabel(row: McpUrlListItem): string {
+		return row.gatewayName ? `${row.gatewayName} · ${row.fqdn}` : row.fqdn;
+	}
+</script>
+
+<PageHeader title="MCP — Custom tools" />
+
+<Card.Root class="mb-6">
+	<Card.Header>
+		<Card.Title class="text-base">MCP URLs</Card.Title>
+		<Card.Description>Derives URLs from gateway FQDNs returned by the API (active expositions).</Card.Description>
+	</Card.Header>
+	<Card.Content class="space-y-4">
+		<div class="flex flex-wrap items-center gap-4">
+			<label class="flex items-center gap-2 text-sm">
+				<input
+					type="radio"
+					name="urlMode"
+					checked={urlMode === 'active'}
+					onchange={() => (urlMode = 'active')}
+				/>
+				Active only
+			</label>
+			<label class="flex items-center gap-2 text-sm">
+				<input
+					type="radio"
+					name="urlMode"
+					checked={urlMode === 'all'}
+					onchange={() => (urlMode = 'all')}
+				/>
+				All expositions (active/&#123;id&#125; per id, 404s ignored)
+			</label>
+			<Button variant="outline" disabled={urlListLoading} onclick={() => void loadMcpUrls()}>
+				{urlListLoading ? 'Loading…' : 'List MCP URLs'}
+			</Button>
+		</div>
+
+		{#if urlList.length > 0}
+			<div class="overflow-x-auto rounded-lg border">
+				<Table.Root class="min-w-[52rem] table-fixed">
+					<Table.Header>
+						<Table.Row>
+							<Table.Head class="w-[38%]">MCP URL</Table.Head>
+							<Table.Head class="w-[12%]">Exposition</Table.Head>
+							<Table.Head class="w-[14%]">Service</Table.Head>
+							<Table.Head class="w-[24%]">Gateway / FQDN</Table.Head>
+							<Table.Head class="w-[12%]">Actions</Table.Head>
+						</Table.Row>
+					</Table.Header>
+					<Table.Body>
+						{#each urlList as row (`${row.expositionId}-${row.url}`)}
+							<Table.Row class="align-top">
+								<Table.Cell class="py-2">
+									<ScrollableCode text={row.url} maxHeight="4.5rem" />
+								</Table.Cell>
+								<Table.Cell class="py-2">
+									<code class="text-xs break-all">{row.expositionId}</code>
+								</Table.Cell>
+								<Table.Cell class="py-2 text-sm">
+									{row.serviceName}:{row.serviceVersion}
+								</Table.Cell>
+								<Table.Cell class="py-2">
+									<ScrollableCode text={gatewayLabel(row)} maxHeight="4.5rem" />
+								</Table.Cell>
+								<Table.Cell class="py-2">
+									<div class="flex flex-col gap-2 sm:flex-row sm:flex-wrap">
+										<Button variant="outline" size="sm" onclick={() => (mcpUrl = row.url)}>
+											Use
+										</Button>
+										<Button size="sm" disabled={loading} onclick={() => void runResolve(row.url)}>
+											Custom tools
+										</Button>
+									</div>
+								</Table.Cell>
+							</Table.Row>
+						{/each}
+					</Table.Body>
+				</Table.Root>
+			</div>
+		{/if}
+
+		{#if !urlListLoading && urlList.length === 0}
+			<p class="text-muted-foreground text-sm">Click &quot;List MCP URLs&quot; to populate the table.</p>
+		{/if}
+	</Card.Content>
+</Card.Root>
+
+<Card.Root class="mb-6">
+	<Card.Header>
+		<Card.Title class="text-base">Custom tools resolution</Card.Title>
+		<Card.Description>
+			From path <code class="text-xs">/mcp/&#123;org&#125;/&#123;service&#125;/&#123;version&#125;</code>, calls control-plane APIs then optionally
+			<code class="text-xs">/api/v1/services/&#123;id&#125;</code>.
+		</Card.Description>
+	</Card.Header>
+	<Card.Content>
+		<form class="space-y-4" onsubmit={onSubmit}>
+			<div class="space-y-2">
+				<Label for="mcp-url">MCP URL</Label>
+				<Textarea
+					id="mcp-url"
+					class="min-h-[2.75rem] resize-y font-mono text-xs break-all"
+					rows={2}
+					bind:value={mcpUrl}
+					placeholder="http://host:port/mcp/org/service/version"
+					autocomplete="off"
+				/>
+			</div>
+			<Button type="submit" disabled={loading}>
+				{loading ? 'Resolving…' : 'Resolve custom tools'}
+			</Button>
+		</form>
+	</Card.Content>
+</Card.Root>
+
+{#if error}
+	<ApiErrorAlert message={error} />
+{/if}
+
+{#if result !== null}
+	<Card.Root class="overflow-hidden">
+		<Card.Header>
+			<Card.Title class="text-base">Resolution result</Card.Title>
+			<Card.Description>
+				{result.source === 'artifacts_custom_tools'
+					? 'Source: RESHAPR_CUSTOM_TOOLS artifact YAML (filtered by includedOperations).'
+					: 'Source: service operations (intersection with includedOperations).'}
+				Exposition <code class="text-xs">{result.expoId}</code>, service
+				<code class="text-xs">{result.serviceId}</code>
+			</Card.Description>
+		</Card.Header>
+		<Card.Content class="space-y-4">
+			{#if tools.length > 0}
+				<div class="flex flex-wrap gap-2">
+					{#each tools as t (t.name)}
+						<Badge variant="outline">{t.name}</Badge>
+					{/each}
+				</div>
+
+				<div class="overflow-x-auto rounded-lg border">
+					<Table.Root>
+						<Table.Header>
+							<Table.Row>
+								<Table.Head class="w-40">Name</Table.Head>
+								<Table.Head>Description</Table.Head>
+							</Table.Row>
+						</Table.Header>
+						<Table.Body>
+							{#each tools as t (t.name)}
+								<Table.Row class="align-top">
+									<Table.Cell class="py-2 font-mono text-xs">{t.name}</Table.Cell>
+									<Table.Cell class="py-2">
+										{#if t.description}
+											<ScrollableCode text={t.description} maxHeight="4rem" />
+										{:else}
+											<span class="text-muted-foreground text-xs">—</span>
+										{/if}
+									</Table.Cell>
+								</Table.Row>
+							{/each}
+						</Table.Body>
+					</Table.Root>
+				</div>
+			{:else}
+				<p class="text-muted-foreground text-sm">No custom tools after filtering.</p>
+			{/if}
+
+			{#if result.artifactYaml}
+				<Collapsible.Root bind:open={yamlOpen} class="rounded-lg border">
+					<Collapsible.Trigger
+						class="hover:bg-muted/50 flex w-full items-center justify-between px-4 py-3 text-left text-sm font-medium"
+						type="button"
+					>
+						RESHAPR_CUSTOM_TOOLS YAML (artifact source)
+						<span class="text-muted-foreground text-xs font-normal">
+							{yamlOpen ? 'Hide' : 'Show'}
+						</span>
+					</Collapsible.Trigger>
+					<Collapsible.Content class="border-t px-2 pb-2">
+						<ScrollableCode text={result.artifactYaml} maxHeight="min(70vh, 28rem)" class="border-0" />
+					</Collapsible.Content>
+				</Collapsible.Root>
+			{/if}
+
+			<Collapsible.Root bind:open={rawJsonOpen} class="rounded-lg border">
+				<Collapsible.Trigger
+					class="hover:bg-muted/50 flex w-full items-center justify-between px-4 py-3 text-left text-sm font-medium"
+					type="button"
+				>
+					Raw JSON (full payload)
+					<span class="text-muted-foreground text-xs font-normal">
+						{rawJsonOpen ? 'Hide' : 'Show'}
+					</span>
+				</Collapsible.Trigger>
+				<Collapsible.Content class="border-t p-2">
+					<ScrollableCode
+						text={JSON.stringify(result, null, 2)}
+						maxHeight="min(50vh, 20rem)"
+						class="border-0"
+					/>
+				</Collapsible.Content>
+			</Collapsible.Root>
+		</Card.Content>
+	</Card.Root>
+{/if}

--- a/web-ui/src/routes/(app)/mcp-custom-tools/+page.svelte
+++ b/web-ui/src/routes/(app)/mcp-custom-tools/+page.svelte
@@ -1,3 +1,19 @@
+<!--
+  ~ Copyright The Reshapr Authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
 <script lang="ts">
 	import { apiClient, ApiError } from '$lib/api/client.js';
 	import ApiErrorAlert from '$lib/components/ApiErrorAlert.svelte';

--- a/web-ui/src/routes/(app)/mcp-prompts/+page.svelte
+++ b/web-ui/src/routes/(app)/mcp-prompts/+page.svelte
@@ -1,0 +1,322 @@
+<script lang="ts">
+	import { apiClient, ApiError } from '$lib/api/client.js';
+	import ApiErrorAlert from '$lib/components/ApiErrorAlert.svelte';
+	import PageHeader from '$lib/components/PageHeader.svelte';
+	import ScrollableCode from '$lib/components/ScrollableCode.svelte';
+	import * as Alert from '$lib/components/ui/alert/index.js';
+	import { Badge } from '$lib/components/ui/badge/index.js';
+	import { Button } from '$lib/components/ui/button/index.js';
+	import * as Card from '$lib/components/ui/card/index.js';
+	import * as Collapsible from '$lib/components/ui/collapsible/index.js';
+	import { Label } from '$lib/components/ui/label/index.js';
+	import * as Table from '$lib/components/ui/table/index.js';
+	import { Textarea } from '$lib/components/ui/textarea/index.js';
+	import { listMcpEndpointUrls, type McpUrlListItem } from '$lib/mcpEndpointUrls.js';
+	import { resolveMcpPromptsFromUrl, type McpPromptsResolution } from '$lib/mcpPrompts.js';
+
+	let mcpUrl = $state('');
+	let urlMode = $state<'active' | 'all'>('active');
+	let urlList = $state<McpUrlListItem[]>([]);
+	let urlListLoading = $state(false);
+	let result = $state<McpPromptsResolution | null>(null);
+	let error = $state<string | null>(null);
+	let loading = $state(false);
+	let rawJsonOpen = $state(false);
+	let yamlOpen = $state(true);
+
+	const prompts = $derived(result?.prompts ?? []);
+
+	async function runListPrompts(url: string) {
+		const trimmed = url.trim();
+		if (!trimmed) {
+			error = 'MCP URL is empty';
+			return;
+		}
+		mcpUrl = trimmed;
+		error = null;
+		result = null;
+		loading = true;
+		try {
+			const c = apiClient();
+			result = await resolveMcpPromptsFromUrl(trimmed, {
+				listServicesPage: (page, size) => c.listServicesPage(page, size),
+				listArtifactsByService: (serviceId) => c.listArtifactsByService(serviceId)
+			});
+			yamlOpen = Boolean(result.artifactYamls.length);
+		} catch (e) {
+			error = e instanceof ApiError ? e.message : String(e);
+		} finally {
+			loading = false;
+		}
+	}
+
+	function onSubmit(ev: SubmitEvent) {
+		ev.preventDefault();
+		void runListPrompts(mcpUrl);
+	}
+
+	async function loadMcpUrls() {
+		error = null;
+		urlListLoading = true;
+		urlList = [];
+		try {
+			const c = apiClient();
+			const items = await listMcpEndpointUrls(urlMode, {
+				listExpositionsActive: () => c.listExpositionsActive(),
+				listExpositionsAll: () => c.listExpositionsAll(),
+				getActiveExpositionOrNull: (id) => c.getActiveExpositionOrNull(id)
+			});
+			urlList = items;
+		} catch (e) {
+			error = e instanceof ApiError ? e.message : String(e);
+		} finally {
+			urlListLoading = false;
+		}
+	}
+
+	function gatewayLabel(row: McpUrlListItem): string {
+		return row.gatewayName ? `${row.gatewayName} · ${row.fqdn}` : row.fqdn;
+	}
+
+	function formatArguments(args: { name: string; description?: string; required?: boolean }[]): string {
+		if (!args.length) return '';
+		return args
+			.map((a) => {
+				const bits = [a.name];
+				if (a.required) bits.push('required');
+				if (a.description) bits.push(a.description);
+				return bits.join(' — ');
+			})
+			.join('\n');
+	}
+</script>
+
+<PageHeader title="MCP — Prompts" />
+
+<Alert.Root class="mb-4">
+	<Alert.Title>Prompts from the control plane</Alert.Title>
+	<Alert.Description class="text-sm">
+		Listing uses artifact <code class="text-xs">RESHAPR_PROMPTS</code> on the service (same path as
+		<a href="/mcp-custom-tools" class="text-primary hover:underline">MCP custom tools</a>), not a direct browser call
+		to the MCP gateway — avoids CORS / <code class="text-xs">Failed to fetch</code>. Attach YAML on
+		<a href="/artifacts" class="text-primary hover:underline">Artifacts → Attach MCP prompts</a>.
+	</Alert.Description>
+</Alert.Root>
+
+<Card.Root class="mb-6">
+	<Card.Header>
+		<Card.Title class="text-base">MCP URLs</Card.Title>
+		<Card.Description>Derives URLs from gateway FQDNs returned by the API (active expositions).</Card.Description>
+	</Card.Header>
+	<Card.Content class="space-y-4">
+		<div class="flex flex-wrap items-center gap-4">
+			<label class="flex items-center gap-2 text-sm">
+				<input
+					type="radio"
+					name="urlModePrompts"
+					checked={urlMode === 'active'}
+					onchange={() => (urlMode = 'active')}
+				/>
+				Active only
+			</label>
+			<label class="flex items-center gap-2 text-sm">
+				<input
+					type="radio"
+					name="urlModePrompts"
+					checked={urlMode === 'all'}
+					onchange={() => (urlMode = 'all')}
+				/>
+				All expositions (active/&#123;id&#125; per id, 404s ignored)
+			</label>
+			<Button variant="outline" disabled={urlListLoading} onclick={() => void loadMcpUrls()}>
+				{urlListLoading ? 'Loading…' : 'List MCP URLs'}
+			</Button>
+		</div>
+
+		{#if urlList.length > 0}
+			<div class="overflow-x-auto rounded-lg border">
+				<Table.Root class="min-w-[52rem] table-fixed">
+					<Table.Header>
+						<Table.Row>
+							<Table.Head class="w-[38%]">MCP URL</Table.Head>
+							<Table.Head class="w-[12%]">Exposition</Table.Head>
+							<Table.Head class="w-[14%]">Service</Table.Head>
+							<Table.Head class="w-[24%]">Gateway / FQDN</Table.Head>
+							<Table.Head class="w-[12%]">Actions</Table.Head>
+						</Table.Row>
+					</Table.Header>
+					<Table.Body>
+						{#each urlList as row (`${row.expositionId}-${row.url}`)}
+							<Table.Row class="align-top">
+								<Table.Cell class="py-2">
+									<ScrollableCode text={row.url} maxHeight="4.5rem" />
+								</Table.Cell>
+								<Table.Cell class="py-2">
+									<code class="text-xs break-all">{row.expositionId}</code>
+								</Table.Cell>
+								<Table.Cell class="py-2 text-sm">
+									{row.serviceName}:{row.serviceVersion}
+								</Table.Cell>
+								<Table.Cell class="py-2">
+									<ScrollableCode text={gatewayLabel(row)} maxHeight="4.5rem" />
+								</Table.Cell>
+								<Table.Cell class="py-2">
+									<div class="flex flex-col gap-2 sm:flex-row sm:flex-wrap">
+										<Button variant="outline" size="sm" onclick={() => (mcpUrl = row.url)}>
+											Use
+										</Button>
+										<Button size="sm" disabled={loading} onclick={() => void runListPrompts(row.url)}>
+											List prompts
+										</Button>
+									</div>
+								</Table.Cell>
+							</Table.Row>
+						{/each}
+					</Table.Body>
+				</Table.Root>
+			</div>
+		{/if}
+
+		{#if !urlListLoading && urlList.length === 0}
+			<p class="text-muted-foreground text-sm">Click &quot;List MCP URLs&quot; to populate the table.</p>
+		{/if}
+	</Card.Content>
+</Card.Root>
+
+<Card.Root class="mb-6">
+	<Card.Header>
+		<Card.Title class="text-base">List prompts</Card.Title>
+		<Card.Description>
+			Resolves <code class="text-xs">RESHAPR_PROMPTS</code> for the service encoded in the MCP URL path.
+		</Card.Description>
+	</Card.Header>
+	<Card.Content>
+		<form class="space-y-4" onsubmit={onSubmit}>
+			<div class="space-y-2">
+				<Label for="mcp-url-prompts">MCP URL</Label>
+				<Textarea
+					id="mcp-url-prompts"
+					class="min-h-[2.75rem] resize-y font-mono text-xs break-all"
+					rows={2}
+					bind:value={mcpUrl}
+					placeholder="http://host:port/mcp/org/service/version"
+					autocomplete="off"
+				/>
+			</div>
+			<Button type="submit" disabled={loading}>
+				{loading ? 'Loading…' : 'List prompts'}
+			</Button>
+		</form>
+	</Card.Content>
+</Card.Root>
+
+{#if error}
+	<ApiErrorAlert message={error} />
+{/if}
+
+{#if result}
+	<Card.Root class="overflow-hidden">
+		<Card.Header>
+			<Card.Title class="text-base">Prompts result</Card.Title>
+			<Card.Description>
+				{prompts.length} prompt(s) from <code class="text-xs">RESHAPR_PROMPTS</code> artifact(s)
+				{#if result.artifactNames.length}
+					— <code class="text-xs">{result.artifactNames.join(', ')}</code>
+				{/if}
+				· service <code class="text-xs">{result.serviceId}</code>
+			</Card.Description>
+		</Card.Header>
+		<Card.Content class="space-y-4">
+			{#if prompts.length > 0}
+				<div class="flex flex-wrap gap-2">
+					{#each prompts as p (p.name)}
+						<Badge variant="outline" title={p.description || undefined}>{p.name}</Badge>
+					{/each}
+				</div>
+
+				<div class="overflow-x-auto rounded-lg border">
+					<Table.Root>
+						<Table.Header>
+							<Table.Row>
+								<Table.Head class="w-40">Name</Table.Head>
+								<Table.Head>Description</Table.Head>
+								<Table.Head class="w-[38%]">Arguments</Table.Head>
+							</Table.Row>
+						</Table.Header>
+						<Table.Body>
+							{#each prompts as p (p.name)}
+								<Table.Row class="align-top">
+									<Table.Cell class="py-2 font-mono text-xs">{p.name}</Table.Cell>
+									<Table.Cell class="py-2">
+										{#if p.description}
+											<ScrollableCode text={p.description} maxHeight="4rem" />
+										{:else}
+											<span class="text-muted-foreground text-xs">—</span>
+										{/if}
+									</Table.Cell>
+									<Table.Cell class="py-2">
+										{#if p.arguments?.length}
+											<ScrollableCode
+												text={formatArguments(p.arguments)}
+												maxHeight="4rem"
+											/>
+										{:else}
+											<span class="text-muted-foreground text-xs">—</span>
+										{/if}
+									</Table.Cell>
+								</Table.Row>
+							{/each}
+						</Table.Body>
+					</Table.Root>
+				</div>
+			{:else}
+				<p class="text-muted-foreground text-sm">No prompts found in the artifact YAML.</p>
+			{/if}
+
+			{#if result.artifactYamls.length > 0}
+				<Collapsible.Root bind:open={yamlOpen} class="rounded-lg border">
+					<Collapsible.Trigger
+						class="hover:bg-muted/50 flex w-full items-center justify-between px-4 py-3 text-left text-sm font-medium"
+						type="button"
+					>
+						RESHAPR_PROMPTS YAML (artifact source)
+						<span class="text-muted-foreground text-xs font-normal">
+							{yamlOpen ? 'Hide' : 'Show'} · {result.artifactYamls.length} file(s)
+						</span>
+					</Collapsible.Trigger>
+					<Collapsible.Content class="space-y-3 border-t p-3">
+						{#each result.artifactYamls as artifact (artifact.name)}
+							<div class="space-y-1">
+								<p class="text-muted-foreground text-xs font-medium">{artifact.name}</p>
+								<ScrollableCode
+									text={artifact.content}
+									maxHeight="min(70vh, 28rem)"
+									class="border-0"
+								/>
+							</div>
+						{/each}
+					</Collapsible.Content>
+				</Collapsible.Root>
+			{/if}
+
+			<Collapsible.Root bind:open={rawJsonOpen} class="rounded-lg border">
+				<Collapsible.Trigger
+					class="hover:bg-muted/50 flex w-full items-center justify-between px-4 py-3 text-left text-sm font-medium"
+					type="button"
+				>
+					Raw JSON (full payload)
+					<span class="text-muted-foreground text-xs font-normal">
+						{rawJsonOpen ? 'Hide' : 'Show'}
+					</span>
+				</Collapsible.Trigger>
+				<Collapsible.Content class="border-t p-2">
+					<ScrollableCode
+						text={JSON.stringify(result, null, 2)}
+						maxHeight="min(50vh, 20rem)"
+						class="border-0"
+					/>
+				</Collapsible.Content>
+			</Collapsible.Root>
+		</Card.Content>
+	</Card.Root>
+{/if}

--- a/web-ui/src/routes/(app)/mcp-prompts/+page.svelte
+++ b/web-ui/src/routes/(app)/mcp-prompts/+page.svelte
@@ -1,3 +1,19 @@
+<!--
+  ~ Copyright The Reshapr Authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
 <script lang="ts">
 	import { apiClient, ApiError } from '$lib/api/client.js';
 	import ApiErrorAlert from '$lib/components/ApiErrorAlert.svelte';

--- a/web-ui/src/routes/(app)/plans/+page.svelte
+++ b/web-ui/src/routes/(app)/plans/+page.svelte
@@ -1,3 +1,19 @@
+<!--
+  ~ Copyright The Reshapr Authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
 <script lang="ts">
 	import { apiClient, ApiError } from '$lib/api/client.js';
 	import ApiErrorAlert from '$lib/components/ApiErrorAlert.svelte';

--- a/web-ui/src/routes/(app)/plans/+page.svelte
+++ b/web-ui/src/routes/(app)/plans/+page.svelte
@@ -1,0 +1,73 @@
+<script lang="ts">
+	import { apiClient, ApiError } from '$lib/api/client.js';
+	import ApiErrorAlert from '$lib/components/ApiErrorAlert.svelte';
+	import PageHeader from '$lib/components/PageHeader.svelte';
+	import { Button } from '$lib/components/ui/button/index.js';
+	import * as Table from '$lib/components/ui/table/index.js';
+
+	type PlanRow = {
+		id: string;
+		name: string;
+		serviceId: string;
+		backendEndpoint: string;
+	};
+
+	let rows = $state<PlanRow[]>([]);
+	let error = $state<string | null>(null);
+
+	async function load() {
+		error = null;
+		try {
+			const data = (await apiClient().listConfigurationPlans()) as PlanRow[];
+			rows = Array.isArray(data) ? data : [];
+		} catch (e) {
+			error = e instanceof ApiError ? e.message : String(e);
+		}
+	}
+
+	$effect(() => {
+		void load();
+	});
+</script>
+
+<PageHeader title="Configuration plans">
+	{#snippet actions()}
+		<Button variant="outline" onclick={() => void load()}>Refresh</Button>
+		<Button href="/plans/new">New plan</Button>
+	{/snippet}
+</PageHeader>
+
+{#if error}
+	<ApiErrorAlert message={error} />
+{/if}
+
+<div class="rounded-lg border">
+	<Table.Root>
+		<Table.Header>
+			<Table.Row>
+				<Table.Head>ID</Table.Head>
+				<Table.Head>Name</Table.Head>
+				<Table.Head>Service</Table.Head>
+				<Table.Head>Backend</Table.Head>
+			</Table.Row>
+		</Table.Header>
+		<Table.Body>
+			{#each rows as p (p.id)}
+				<Table.Row>
+					<Table.Cell>
+						<a href="/plans/{p.id}" class="text-primary hover:underline">{p.id}</a>
+					</Table.Cell>
+					<Table.Cell>{p.name}</Table.Cell>
+					<Table.Cell>{p.serviceId}</Table.Cell>
+					<Table.Cell class="max-w-xs truncate" title={p.backendEndpoint}>
+						{p.backendEndpoint}
+					</Table.Cell>
+				</Table.Row>
+			{/each}
+		</Table.Body>
+	</Table.Root>
+</div>
+
+{#if rows.length === 0 && !error}
+	<p class="text-muted-foreground mt-4 text-sm">No plans.</p>
+{/if}

--- a/web-ui/src/routes/(app)/plans/[id]/+page.svelte
+++ b/web-ui/src/routes/(app)/plans/[id]/+page.svelte
@@ -1,3 +1,19 @@
+<!--
+  ~ Copyright The Reshapr Authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
 <script lang="ts">
 	import { page } from '$app/state';
 	import { goto } from '$app/navigation';

--- a/web-ui/src/routes/(app)/plans/[id]/+page.svelte
+++ b/web-ui/src/routes/(app)/plans/[id]/+page.svelte
@@ -1,0 +1,173 @@
+<script lang="ts">
+	import { page } from '$app/state';
+	import { goto } from '$app/navigation';
+	import { apiClient, ApiError } from '$lib/api/client.js';
+	import ApiErrorAlert from '$lib/components/ApiErrorAlert.svelte';
+	import { Button } from '$lib/components/ui/button/index.js';
+	import * as Alert from '$lib/components/ui/alert/index.js';
+	import { Label } from '$lib/components/ui/label/index.js';
+	import { Textarea } from '$lib/components/ui/textarea/index.js';
+	import * as Card from '$lib/components/ui/card/index.js';
+	import { formatOperationsList, parseOperationsList } from '$lib/operationsList.js';
+
+	const id = $derived(page.params.id);
+
+	let raw = $state('');
+	let includedOperationsText = $state('');
+	let excludedOperationsText = $state('');
+	let error = $state<string | null>(null);
+	let apiKeyShown = $state<string | null>(null);
+	let loading = $state(true);
+
+	async function load() {
+		if (!id) return;
+		error = null;
+		try {
+			const p = await apiClient().getConfigurationPlan(id);
+			raw = JSON.stringify(p, null, 2);
+			syncOperationsFromRaw();
+		} catch (e) {
+			error = e instanceof ApiError ? e.message : String(e);
+		} finally {
+			loading = false;
+		}
+	}
+
+	$effect(() => {
+		loading = true;
+		void load();
+	});
+
+	function syncOperationsFromRaw() {
+		try {
+			const p = JSON.parse(raw) as Record<string, unknown>;
+			includedOperationsText = formatOperationsList(p.includedOperations);
+			excludedOperationsText = formatOperationsList(p.excludedOperations);
+		} catch {
+			/* raw not valid JSON yet */
+		}
+	}
+
+	function applyOperationsToDocument() {
+		error = null;
+		try {
+			const p = JSON.parse(raw) as Record<string, unknown>;
+			const includedOperations = parseOperationsList(includedOperationsText);
+			const excludedOperations = parseOperationsList(excludedOperationsText);
+			if (includedOperations.length) p.includedOperations = includedOperations;
+			else delete p.includedOperations;
+			if (excludedOperations.length) p.excludedOperations = excludedOperations;
+			else delete p.excludedOperations;
+			raw = JSON.stringify(p, null, 2);
+		} catch (e) {
+			error = e instanceof Error ? e.message : String(e);
+		}
+	}
+
+	async function onSave(ev: SubmitEvent) {
+		ev.preventDefault();
+		if (!id) return;
+		error = null;
+		applyOperationsToDocument();
+		if (error) return;
+		try {
+			const parsed = JSON.parse(raw) as Record<string, unknown>;
+			await apiClient().updateConfigurationPlan(id, parsed);
+			await load();
+		} catch (e) {
+			error = e instanceof ApiError ? e.message : String(e);
+		}
+	}
+
+	async function onRenew() {
+		if (!id) return;
+		error = null;
+		try {
+			const out = (await apiClient().renewApiKey(id)) as { apiKey?: string };
+			apiKeyShown = out.apiKey ?? '(see server response)';
+			await load();
+		} catch (e) {
+			error = e instanceof ApiError ? e.message : String(e);
+		}
+	}
+
+	async function onDelete() {
+		if (!id || !confirm('Delete this plan?')) return;
+		try {
+			await apiClient().deleteConfigurationPlan(id);
+			goto('/plans');
+		} catch (e) {
+			error = e instanceof ApiError ? e.message : String(e);
+		}
+	}
+</script>
+
+<p class="mb-4">
+	<a href="/plans" class="text-primary text-sm hover:underline">← Plans</a>
+</p>
+
+<div class="mb-6 flex flex-wrap items-center justify-between gap-4">
+	<h2 class="text-xl font-semibold tracking-tight">Plan {id}</h2>
+	<div class="flex flex-wrap gap-2">
+		<Button variant="outline" onclick={() => void onRenew()}>Renew API key</Button>
+		<Button variant="destructive" onclick={() => void onDelete()}>Delete</Button>
+	</div>
+	</div>
+
+{#if apiKeyShown}
+	<Alert.Root class="mb-4">
+		<Alert.Title>New API key</Alert.Title>
+		<Alert.Description>
+			<code class="text-xs break-all">{apiKeyShown}</code>
+		</Alert.Description>
+	</Alert.Root>
+{/if}
+
+{#if error}
+	<ApiErrorAlert message={error} />
+{/if}
+
+<Card.Root class="mb-6 max-w-2xl">
+	<Card.Header>
+		<Card.Title class="text-base">Operations filter</Card.Title>
+		<Card.Description>
+			Equivalent to <code class="text-xs">--io</code> / <code class="text-xs">--eo</code> on
+			<code class="text-xs">reshapr config create</code>. Merged into the JSON below on save.
+		</Card.Description>
+	</Card.Header>
+	<Card.Content class="space-y-4">
+		<div class="space-y-2">
+			<Label for="includedOps">Included operations</Label>
+			<Textarea
+				id="includedOps"
+				bind:value={includedOperationsText}
+				rows={4}
+				class="font-mono text-xs"
+				disabled={loading}
+				placeholder={'POST /tests/{testId}/start\nGET /masters'}
+			/>
+		</div>
+		<div class="space-y-2">
+			<Label for="excludedOps">Excluded operations (optional)</Label>
+			<Textarea
+				id="excludedOps"
+				bind:value={excludedOperationsText}
+				rows={3}
+				class="font-mono text-xs"
+				disabled={loading}
+			/>
+		</div>
+		<Button type="button" variant="outline" disabled={loading} onclick={() => applyOperationsToDocument()}>
+			Preview in JSON
+		</Button>
+	</Card.Content>
+</Card.Root>
+
+<form class="space-y-4" onsubmit={onSave}>
+	<p class="text-muted-foreground text-sm">
+		Full JSON edit (PUT). Keep <code class="text-xs">id</code> and
+		<code class="text-xs">organizationId</code> from the loaded document.
+	</p>
+	<Textarea class="font-mono text-xs" rows={22} bind:value={raw} disabled={loading} />
+	<Button type="submit">Save</Button>
+</form>

--- a/web-ui/src/routes/(app)/plans/[id]/+page.ts
+++ b/web-ui/src/routes/(app)/plans/[id]/+page.ts
@@ -1,0 +1,1 @@
+export const prerender = false;

--- a/web-ui/src/routes/(app)/plans/[id]/+page.ts
+++ b/web-ui/src/routes/(app)/plans/[id]/+page.ts
@@ -1,1 +1,17 @@
+/*
+ * Copyright The Reshapr Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 export const prerender = false;

--- a/web-ui/src/routes/(app)/plans/new/+page.svelte
+++ b/web-ui/src/routes/(app)/plans/new/+page.svelte
@@ -1,0 +1,158 @@
+<script lang="ts">
+	import { goto } from '$app/navigation';
+	import { apiClient, ApiError } from '$lib/api/client.js';
+	import ApiErrorAlert from '$lib/components/ApiErrorAlert.svelte';
+	import PageHeader from '$lib/components/PageHeader.svelte';
+	import * as Alert from '$lib/components/ui/alert/index.js';
+	import { Button } from '$lib/components/ui/button/index.js';
+	import * as Card from '$lib/components/ui/card/index.js';
+	import { Checkbox } from '$lib/components/ui/checkbox/index.js';
+	import { Input } from '$lib/components/ui/input/index.js';
+	import { Label } from '$lib/components/ui/label/index.js';
+	import { Textarea } from '$lib/components/ui/textarea/index.js';
+	import { parseOperationsList } from '$lib/operationsList.js';
+
+	let error = $state<string | null>(null);
+	let apiKeyShown = $state<string | null>(null);
+	let createdId = $state<string | null>(null);
+	let genKey = $state(false);
+	let includedOperationsText = $state('');
+	let excludedOperationsText = $state('');
+
+	async function onSubmit(ev: SubmitEvent) {
+		ev.preventDefault();
+		error = null;
+		apiKeyShown = null;
+		createdId = null;
+		const fd = new FormData(ev.target as HTMLFormElement);
+		const name = String(fd.get('name') || '');
+		const serviceId = String(fd.get('serviceId') || '');
+		const backendEndpoint = String(fd.get('backendEndpoint') || '');
+		const description = String(fd.get('description') || '') || undefined;
+		const backendSecretId = String(fd.get('backendSecretId') || '') || undefined;
+		if (!name || !serviceId || !backendEndpoint) {
+			error = 'name, serviceId, and backendEndpoint are required.';
+			return;
+		}
+		try {
+			const includedOperations = parseOperationsList(includedOperationsText);
+			const excludedOperations = parseOperationsList(excludedOperationsText);
+
+			const body: Record<string, unknown> = {
+				name,
+				serviceId,
+				backendEndpoint,
+				description,
+				backendSecretId
+			};
+			if (includedOperations.length) body.includedOperations = includedOperations;
+			if (excludedOperations.length) body.excludedOperations = excludedOperations;
+			if (genKey) body.apiKey = 'generate-me';
+
+			const out = (await apiClient().createConfigurationPlan(body)) as {
+				id: string;
+				apiKey?: string;
+			};
+			createdId = out.id;
+			if (out.apiKey) apiKeyShown = out.apiKey;
+			else goto(`/plans/${out.id}`);
+		} catch (e) {
+			error = e instanceof ApiError ? e.message : String(e);
+		}
+	}
+</script>
+
+<PageHeader title="New plan" />
+
+<Alert.Root class="mb-4">
+	<Alert.Title>Configuration plan</Alert.Title>
+	<Alert.Description>
+		Same as <code class="text-xs">reshapr config create</code>. Use <strong>Included operations</strong>
+		(<code class="text-xs">--io</code>) to expose only selected API routes. Attach a
+		<code class="text-xs">CustomTools</code> YAML on <a href="/artifacts" class="text-primary hover:underline">Artifacts</a>
+		for MCP custom tools (step 2).
+	</Alert.Description>
+</Alert.Root>
+
+{#if apiKeyShown}
+	<Alert.Root class="mb-4">
+		<Alert.Title>API key (copy now)</Alert.Title>
+		<Alert.Description>
+			<code class="text-xs break-all">{apiKeyShown}</code>
+			<p class="mt-2">
+				<a href={createdId ? `/plans/${createdId}` : '/plans'} class="text-primary hover:underline">
+					Open created plan
+				</a>
+			</p>
+		</Alert.Description>
+	</Alert.Root>
+{/if}
+
+{#if error}
+	<ApiErrorAlert message={error} />
+{/if}
+
+<Card.Root class="max-w-2xl">
+	<Card.Content class="pt-6">
+		<form class="space-y-4" onsubmit={onSubmit}>
+			<div class="space-y-2">
+				<Label for="name">Name</Label>
+				<Input id="name" name="name" placeholder="blazemeter-tests-operations" required />
+			</div>
+			<div class="space-y-2">
+				<Label for="serviceId">Service ID</Label>
+				<Input id="serviceId" name="serviceId" placeholder="from Services list" required />
+			</div>
+			<div class="space-y-2">
+				<Label for="backendEndpoint">Backend endpoint URL</Label>
+				<Input
+					id="backendEndpoint"
+					name="backendEndpoint"
+					class="w-full"
+					placeholder="https://a.blazemeter.com/api/v4"
+					required
+				/>
+			</div>
+			<div class="space-y-2">
+				<Label for="description">Description</Label>
+				<Input id="description" name="description" />
+			</div>
+			<div class="space-y-2">
+				<Label for="backendSecretId">Backend secret ID</Label>
+				<Input id="backendSecretId" name="backendSecretId" />
+			</div>
+
+			<div class="space-y-2">
+				<Label for="includedOperations">Included operations (<code class="text-xs">--io</code>)</Label>
+				<Textarea
+					id="includedOperations"
+					bind:value={includedOperationsText}
+					rows={4}
+					class="font-mono text-xs"
+					placeholder={'POST /tests/{testId}/start\nGET /masters'}
+				/>
+				<p class="text-muted-foreground text-xs">
+					One operation per line, or a JSON array. Leave empty to include all service operations (after
+					custom-tools filtering).
+				</p>
+			</div>
+
+			<div class="space-y-2">
+				<Label for="excludedOperations">Excluded operations (<code class="text-xs">--eo</code>, optional)</Label>
+				<Textarea
+					id="excludedOperations"
+					bind:value={excludedOperationsText}
+					rows={3}
+					class="font-mono text-xs"
+					placeholder="Only used when included operations is empty"
+				/>
+			</div>
+
+			<div class="flex items-center gap-2">
+				<Checkbox id="apiKey" bind:checked={genKey} />
+				<Label for="apiKey">Generate an API key</Label>
+			</div>
+			<Button type="submit">Create plan</Button>
+		</form>
+	</Card.Content>
+</Card.Root>

--- a/web-ui/src/routes/(app)/plans/new/+page.svelte
+++ b/web-ui/src/routes/(app)/plans/new/+page.svelte
@@ -1,3 +1,19 @@
+<!--
+  ~ Copyright The Reshapr Authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
 <script lang="ts">
 	import { goto } from '$app/navigation';
 	import { apiClient, ApiError } from '$lib/api/client.js';

--- a/web-ui/src/routes/(app)/quotas/+page.svelte
+++ b/web-ui/src/routes/(app)/quotas/+page.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+	import { apiClient, ApiError } from '$lib/api/client.js';
+	import ApiErrorAlert from '$lib/components/ApiErrorAlert.svelte';
+	import JsonBlock from '$lib/components/JsonBlock.svelte';
+	import PageHeader from '$lib/components/PageHeader.svelte';
+
+	let data = $state<unknown>(null);
+	let error = $state<string | null>(null);
+	let loading = $state(true);
+
+	$effect(() => {
+		(async () => {
+			try {
+				error = null;
+				data = await apiClient().getQuotas();
+			} catch (e) {
+				error = e instanceof ApiError ? e.message : String(e);
+			} finally {
+				loading = false;
+			}
+		})();
+	});
+</script>
+
+<PageHeader title="Quotas" />
+
+{#if error}
+	<ApiErrorAlert message={error} />
+{/if}
+
+<JsonBlock value={data} {loading} />

--- a/web-ui/src/routes/(app)/quotas/+page.svelte
+++ b/web-ui/src/routes/(app)/quotas/+page.svelte
@@ -1,3 +1,19 @@
+<!--
+  ~ Copyright The Reshapr Authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
 <script lang="ts">
 	import { apiClient, ApiError } from '$lib/api/client.js';
 	import ApiErrorAlert from '$lib/components/ApiErrorAlert.svelte';

--- a/web-ui/src/routes/(app)/secrets/+page.svelte
+++ b/web-ui/src/routes/(app)/secrets/+page.svelte
@@ -1,3 +1,19 @@
+<!--
+  ~ Copyright The Reshapr Authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
 <script lang="ts">
 	import { apiClient } from '$lib/api/client.js';
 	import { formatApiError } from '$lib/format-api-error.js';

--- a/web-ui/src/routes/(app)/secrets/+page.svelte
+++ b/web-ui/src/routes/(app)/secrets/+page.svelte
@@ -1,0 +1,99 @@
+<script lang="ts">
+	import { apiClient } from '$lib/api/client.js';
+	import { formatApiError } from '$lib/format-api-error.js';
+	import ApiErrorAlert from '$lib/components/ApiErrorAlert.svelte';
+	import PageHeader from '$lib/components/PageHeader.svelte';
+	import { Button } from '$lib/components/ui/button/index.js';
+	import * as Card from '$lib/components/ui/card/index.js';
+	import * as Table from '$lib/components/ui/table/index.js';
+
+	type SecretRefRow = {
+		id?: string;
+		organizationId?: string;
+		name?: string;
+		description?: string;
+		type?: string;
+	};
+
+	let rows = $state<SecretRefRow[]>([]);
+	let error = $state<string | null>(null);
+
+	function asRefRows(data: unknown[]): SecretRefRow[] {
+		return data.filter((r): r is SecretRefRow => r !== null && typeof r === 'object');
+	}
+
+	async function load() {
+		error = null;
+		try {
+			const data = await apiClient().listSecretRefs();
+			rows = asRefRows(Array.isArray(data) ? data : []);
+		} catch (e) {
+			error = formatApiError(e);
+		}
+	}
+
+	$effect(() => {
+		void load();
+	});
+</script>
+
+<PageHeader title="Secrets">
+	{#snippet actions()}
+		<Button variant="outline" onclick={() => void load()}>Refresh</Button>
+	{/snippet}
+</PageHeader>
+
+<p class="text-muted-foreground mb-4 text-sm">
+	Same data as <code class="text-xs">reshapr secret list</code> via
+	<code class="text-xs">GET /api/v1/secrets/refs</code> — see
+	<a
+		href="https://github.com/reshaprio/reshapr/blob/main/cli/src/commands/secret.ts"
+		target="_blank"
+		rel="noreferrer"
+		class="text-primary hover:underline"
+	>
+		cli/src/commands/secret.ts
+	</a>.
+</p>
+
+{#if error}
+	<ApiErrorAlert message={error} />
+{/if}
+
+<Card.Root>
+	<Card.Content class="pt-6">
+		<p class="text-muted-foreground mb-4 text-sm">
+			{rows.length} secret{rows.length === 1 ? '' : 's'}
+		</p>
+		{#if rows.length === 0 && !error}
+			<p class="text-muted-foreground text-sm">No secrets.</p>
+		{:else}
+			<div class="rounded-lg border">
+				<Table.Root>
+					<Table.Header>
+						<Table.Row>
+							<Table.Head>ID</Table.Head>
+							<Table.Head>Organization</Table.Head>
+							<Table.Head>Name</Table.Head>
+							<Table.Head>Type</Table.Head>
+							<Table.Head>Description</Table.Head>
+						</Table.Row>
+					</Table.Header>
+					<Table.Body>
+						{#each rows as row (row.id ?? `${row.name}-${row.organizationId}`)}
+							<Table.Row>
+								<Table.Cell><code class="text-xs">{row.id ?? '—'}</code></Table.Cell>
+								<Table.Cell><code class="text-xs">{row.organizationId ?? '—'}</code></Table.Cell>
+								<Table.Cell>{row.name ?? '—'}</Table.Cell>
+								<Table.Cell><code class="text-xs">{row.type ?? '—'}</code></Table.Cell>
+								<Table.Cell class="text-muted-foreground">
+									{row.description?.trim() ? row.description : '—'}
+								</Table.Cell>
+							</Table.Row>
+						{/each}
+					</Table.Body>
+				</Table.Root>
+			</div>
+		{/if}
+	</Card.Content>
+</Card.Root>

--- a/web-ui/src/routes/(app)/services/+page.svelte
+++ b/web-ui/src/routes/(app)/services/+page.svelte
@@ -2,19 +2,20 @@
 	import { apiClient, ApiError } from '$lib/api/client.js';
 	import ApiErrorAlert from '$lib/components/ApiErrorAlert.svelte';
 	import PageHeader from '$lib/components/PageHeader.svelte';
+	import { Badge } from '$lib/components/ui/badge/index.js';
 	import { Button } from '$lib/components/ui/button/index.js';
-	import * as Table from '$lib/components/ui/table/index.js';
-	import { formatRelativeAge } from '$lib/utils/relativeAge.js';
+	import * as Card from '$lib/components/ui/card/index.js';
 
-	type ServiceRow = {
+	type Service = {
 		id: string;
 		name: string;
 		version: string;
 		type: string;
-		age: string;
+		createdOn: string;
 	};
 
-	let rows = $state<ServiceRow[]>([]);
+	let services = $state<Service[]>([]);
+	let loading = $state(true);
 	let error = $state<string | null>(null);
 
 	function pickType(raw: unknown): string {
@@ -23,33 +24,63 @@
 		return String(raw);
 	}
 
-	function toServiceRow(raw: unknown): ServiceRow | null {
+	function toService(raw: unknown): Service | null {
 		if (!raw || typeof raw !== 'object') return null;
 		const o = raw as Record<string, unknown>;
 		if (typeof o.id !== 'string') return null;
-		const created =
+		const createdOn =
 			typeof o.createdOn === 'string'
 				? o.createdOn
 				: typeof o.created === 'string'
 					? o.created
-					: undefined;
+					: '';
 		return {
 			id: o.id,
 			name: typeof o.name === 'string' ? o.name : '—',
 			version: typeof o.version === 'string' ? o.version : '—',
 			type: pickType(o.type),
-			age: formatRelativeAge(created)
+			createdOn
 		};
 	}
 
+	function formatDate(iso: string): string {
+		if (!iso) return '—';
+		try {
+			return new Date(iso).toLocaleDateString(undefined, {
+				year: 'numeric',
+				month: 'short',
+				day: 'numeric'
+			});
+		} catch {
+			return iso;
+		}
+	}
+
+	function typeBadgeStyle(type: string): string {
+		switch (type?.toUpperCase()) {
+			case 'REST':
+				return 'background-color: #6BBD4F; color: white;';
+			case 'GRAPHQL':
+				return 'background-color: #E10098; color: white;';
+			case 'GRPC':
+				return 'background-color: #c0a16b; color: white;';
+			default:
+				return '';
+		}
+	}
+
 	async function load() {
+		loading = true;
 		error = null;
 		try {
 			const data = (await apiClient().listServices()) as unknown[];
 			const list = Array.isArray(data) ? data : [];
-			rows = list.map(toServiceRow).filter((r): r is ServiceRow => r != null);
+			services = list.map(toService).filter((s): s is Service => s != null);
 		} catch (e) {
 			error = e instanceof ApiError ? e.message : String(e);
+			services = [];
+		} finally {
+			loading = false;
 		}
 	}
 
@@ -64,43 +95,61 @@
 
 <PageHeader title="Services">
 	{#snippet actions()}
-		<Button variant="outline" onclick={() => void load()}>Refresh</Button>
+		<Button variant="outline" disabled={loading} onclick={() => void load()}>Refresh</Button>
 	{/snippet}
 </PageHeader>
 
-{#if error}
+<p class="text-muted-foreground mb-6 text-sm">
+	API services registered in your organization.
+</p>
+
+{#if loading}
+	<div class="flex justify-center py-12">
+		<div
+			class="border-primary h-8 w-8 animate-spin rounded-full border-2 border-t-transparent"
+		></div>
+	</div>
+{:else if error}
 	<ApiErrorAlert message={error} />
-{/if}
-
-<div class="rounded-lg border">
-	<Table.Root>
-		<Table.Header>
-			<Table.Row>
-				<Table.Head>ID</Table.Head>
-				<Table.Head>NAME</Table.Head>
-				<Table.Head>VERSION</Table.Head>
-				<Table.Head>TYPE</Table.Head>
-				<Table.Head>AGE</Table.Head>
-				<Table.Head class="w-[100px]" />
-			</Table.Row>
-		</Table.Header>
-		<Table.Body>
-			{#each rows as s (s.id)}
-				<Table.Row>
-					<Table.Cell><code class="text-xs">{s.id}</code></Table.Cell>
-					<Table.Cell class="font-medium">{s.name}</Table.Cell>
-					<Table.Cell>{s.version}</Table.Cell>
-					<Table.Cell>{s.type}</Table.Cell>
-					<Table.Cell>{s.age}</Table.Cell>
-					<Table.Cell>
-						<Button variant="outline" size="sm" href="/services/{s.id}">Open</Button>
-					</Table.Cell>
-				</Table.Row>
-			{/each}
-		</Table.Body>
-	</Table.Root>
-</div>
-
-{#if rows.length === 0 && !error}
-	<p class="text-muted-foreground mt-4 text-sm">No services.</p>
+	<div class="mt-4 text-center">
+		<Button variant="outline" onclick={() => void load()}>Retry</Button>
+	</div>
+{:else if services.length === 0}
+	<Card.Root>
+		<Card.Content class="py-12 text-center">
+			<p class="text-muted-foreground">No services found. Import a service to get started.</p>
+		</Card.Content>
+	</Card.Root>
+{:else}
+	<div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+		{#each services as service (service.id)}
+			<a href="/services/{service.id}" class="block">
+				<Card.Root
+					class="flex h-full flex-col transition-colors hover:border-primary/50 hover:bg-accent/50"
+				>
+					<Card.Header class="flex-1">
+						<div class="flex min-w-0 items-start justify-between gap-2">
+							<Card.Title class="min-w-0 flex-1 text-base leading-snug break-all">
+								{service.name}
+							</Card.Title>
+							<Badge class="shrink-0" style={typeBadgeStyle(service.type)}>
+								{service.type}
+							</Badge>
+						</div>
+						<Card.Description class="mt-1">
+							Version: <b>{service.version}</b>
+						</Card.Description>
+					</Card.Header>
+					<Card.Content class="pt-0">
+						<div class="text-muted-foreground space-y-1 text-xs">
+							<p>Created {formatDate(service.createdOn)}</p>
+							<p class="truncate">
+								<code class="bg-muted rounded px-1 py-0.5 font-mono">{service.id}</code>
+							</p>
+						</div>
+					</Card.Content>
+				</Card.Root>
+			</a>
+		{/each}
+	</div>
 {/if}

--- a/web-ui/src/routes/(app)/services/+page.svelte
+++ b/web-ui/src/routes/(app)/services/+page.svelte
@@ -1,3 +1,19 @@
+<!--
+  ~ Copyright The Reshapr Authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
 <script lang="ts">
 	import { apiClient, ApiError } from '$lib/api/client.js';
 	import ApiErrorAlert from '$lib/components/ApiErrorAlert.svelte';

--- a/web-ui/src/routes/(app)/services/+page.svelte
+++ b/web-ui/src/routes/(app)/services/+page.svelte
@@ -1,143 +1,106 @@
-<!--
-  ~ Copyright The Reshapr Authors.
-  ~
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
-  ~
-  ~ http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
-  -->
-
 <script lang="ts">
-  import { onMount } from 'svelte';
-  import { Badge } from '$lib/components/ui/badge/index.js';
-  import { Card, CardHeader, CardTitle, CardDescription, CardContent } from '$lib/components/ui/card/index.js';
+	import { apiClient, ApiError } from '$lib/api/client.js';
+	import ApiErrorAlert from '$lib/components/ApiErrorAlert.svelte';
+	import PageHeader from '$lib/components/PageHeader.svelte';
+	import { Button } from '$lib/components/ui/button/index.js';
+	import * as Table from '$lib/components/ui/table/index.js';
+	import { formatRelativeAge } from '$lib/utils/relativeAge.js';
 
-  interface Service {
-    id: string;
-    name: string;
-    version: string;
-    type: string;
-    createdOn: string;
-    organizationId: string;
-  }
+	type ServiceRow = {
+		id: string;
+		name: string;
+		version: string;
+		type: string;
+		age: string;
+	};
 
-  let services = $state<Service[]>([]);
-  let loading = $state(true);
-  let error = $state('');
+	let rows = $state<ServiceRow[]>([]);
+	let error = $state<string | null>(null);
 
-  onMount(async () => {
-    await loadServices();
-  });
+	function pickType(raw: unknown): string {
+		if (raw == null) return '—';
+		if (typeof raw === 'string') return raw;
+		return String(raw);
+	}
 
-  async function loadServices() {
-    loading = true;
-    error = '';
+	function toServiceRow(raw: unknown): ServiceRow | null {
+		if (!raw || typeof raw !== 'object') return null;
+		const o = raw as Record<string, unknown>;
+		if (typeof o.id !== 'string') return null;
+		const created =
+			typeof o.createdOn === 'string'
+				? o.createdOn
+				: typeof o.created === 'string'
+					? o.created
+					: undefined;
+		return {
+			id: o.id,
+			name: typeof o.name === 'string' ? o.name : '—',
+			version: typeof o.version === 'string' ? o.version : '—',
+			type: pickType(o.type),
+			age: formatRelativeAge(created)
+		};
+	}
 
-    try {
-      const res = await fetch('/api/v1/services?page=0&size=20');
+	async function load() {
+		error = null;
+		try {
+			const data = (await apiClient().listServices()) as unknown[];
+			const list = Array.isArray(data) ? data : [];
+			rows = list.map(toServiceRow).filter((r): r is ServiceRow => r != null);
+		} catch (e) {
+			error = e instanceof ApiError ? e.message : String(e);
+		}
+	}
 
-      if (!res.ok) {
-        error = `Failed to load services (${res.status}): ${res.statusText}`;
-        return;
-      }
-
-      services = await res.json();
-    } catch {
-      error = 'Network error. Please try again.';
-    } finally {
-      loading = false;
-    }
-  }
-
-  function formatDate(iso: string): string {
-    try {
-      return new Date(iso).toLocaleDateString(undefined, {
-        year: 'numeric',
-        month: 'short',
-        day: 'numeric'
-      });
-    } catch {
-      return iso;
-    }
-  }
-
-  function typeBadgeStyle(type: string): string {
-    switch (type?.toUpperCase()) {
-      case 'REST': return 'background-color: #6BBD4F; color: white;';
-      case 'GRAPHQL': return 'background-color: #E10098; color: white;';
-      case 'GRPC': return 'background-color: #c0a16b; color: white;';
-      default: return '';
-    }
-  }
+	$effect(() => {
+		void load();
+	});
 </script>
 
 <svelte:head>
-  <title>Services — reShapr</title>
+	<title>Services — reShapr</title>
 </svelte:head>
 
-<div class="p-6">
-  <div class="space-y-6">
-    <div>
-      <h1 class="text-2xl font-bold tracking-tight">Services</h1>
-      <p class="text-muted-foreground">API services registered in your organization.</p>
-    </div>
+<PageHeader title="Services">
+	{#snippet actions()}
+		<Button variant="outline" onclick={() => void load()}>Refresh</Button>
+	{/snippet}
+</PageHeader>
 
-    {#if loading}
-      <div class="flex justify-center py-12">
-        <div class="h-8 w-8 animate-spin rounded-full border-2 border-primary border-t-transparent"></div>
-      </div>
-    {:else if error}
-      <Card>
-        <CardContent class="py-8 text-center">
-          <p class="text-destructive">{error}</p>
-          <button
-            class="mt-4 text-sm text-primary underline-offset-4 hover:underline"
-            onclick={loadServices}
-          >
-            Retry
-          </button>
-        </CardContent>
-      </Card>
-    {:else if services.length === 0}
-      <Card>
-        <CardContent class="py-12 text-center">
-          <p class="text-muted-foreground">No services found. Import a service to get started.</p>
-        </CardContent>
-      </Card>
-    {:else}
-      <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
-        {#each services as service (service.id)}
-          <Card class="flex flex-col transition-colors hover:border-primary/50 hover:bg-accent/50">
-            <CardHeader class="flex-1">
-              <div class="flex items-start justify-between gap-2 min-w-0">
-                <CardTitle class="text-base leading-snug break-all min-w-0">{service.name}</CardTitle>
-                <Badge class="shrink-0" style={typeBadgeStyle(service.type)}>
-                  {service.type}
-                </Badge>
-              </div>
-              <CardDescription class="mt-1">
-                Version: <b>{service.version}</b>
-              </CardDescription>
-            </CardHeader>
-            <CardContent class="pt-0">
-              <div class="space-y-1 text-xs text-muted-foreground">
-                <p>Created {formatDate(service.createdOn)}</p>
-                <p class="truncate">
-                  <code class="rounded bg-muted px-1 py-0.5 font-mono">{service.id}</code>
-                </p>
-              </div>
-            </CardContent>
-          </Card>
-        {/each}
-      </div>
-    {/if}
-  </div>
+{#if error}
+	<ApiErrorAlert message={error} />
+{/if}
+
+<div class="rounded-lg border">
+	<Table.Root>
+		<Table.Header>
+			<Table.Row>
+				<Table.Head>ID</Table.Head>
+				<Table.Head>NAME</Table.Head>
+				<Table.Head>VERSION</Table.Head>
+				<Table.Head>TYPE</Table.Head>
+				<Table.Head>AGE</Table.Head>
+				<Table.Head class="w-[100px]" />
+			</Table.Row>
+		</Table.Header>
+		<Table.Body>
+			{#each rows as s (s.id)}
+				<Table.Row>
+					<Table.Cell><code class="text-xs">{s.id}</code></Table.Cell>
+					<Table.Cell class="font-medium">{s.name}</Table.Cell>
+					<Table.Cell>{s.version}</Table.Cell>
+					<Table.Cell>{s.type}</Table.Cell>
+					<Table.Cell>{s.age}</Table.Cell>
+					<Table.Cell>
+						<Button variant="outline" size="sm" href="/services/{s.id}">Open</Button>
+					</Table.Cell>
+				</Table.Row>
+			{/each}
+		</Table.Body>
+	</Table.Root>
 </div>
 
+{#if rows.length === 0 && !error}
+	<p class="text-muted-foreground mt-4 text-sm">No services.</p>
+{/if}

--- a/web-ui/src/routes/(app)/services/[id]/+layout.svelte
+++ b/web-ui/src/routes/(app)/services/[id]/+layout.svelte
@@ -1,0 +1,141 @@
+<script lang="ts">
+	import { goto } from '$app/navigation';
+	import { page } from '$app/state';
+	import { setContext } from 'svelte';
+	import { apiClient, ApiError } from '$lib/api/client.js';
+	import ApiErrorAlert from '$lib/components/ApiErrorAlert.svelte';
+	import { parseServiceRecord } from '$lib/serviceHub.js';
+	import { SERVICE_CONTEXT_KEY, type ServiceContextValue } from '$lib/serviceContext.js';
+	import { Button } from '$lib/components/ui/button/index.js';
+	import { cn } from '$lib/utils.js';
+
+	let { children } = $props();
+
+	const serviceId = $derived(page.params.id ?? '');
+
+	const subNav: { href: (id: string) => string; label: string; exact?: boolean }[] = [
+		{ href: (id) => `/services/${id}`, label: 'Overview', exact: true },
+		{ href: (id) => `/services/${id}/artifacts`, label: 'Artifacts' },
+		{ href: (id) => `/services/${id}/plans`, label: 'Configuration plans' },
+		{ href: (id) => `/services/${id}/expositions`, label: 'Expositions' },
+		{ href: (id) => `/services/${id}/mcp-custom-tools`, label: 'MCP custom tools' },
+		{ href: (id) => `/services/${id}/mcp-prompts`, label: 'MCP prompts' }
+	];
+
+	let raw = $state<unknown>(null);
+	let service = $state<ReturnType<typeof parseServiceRecord>>(null);
+	let loading = $state(true);
+	let error = $state<string | null>(null);
+
+	async function refresh() {
+		if (!serviceId) return;
+		loading = true;
+		error = null;
+		try {
+			const data = await apiClient().getService(serviceId);
+			raw = data;
+			service = parseServiceRecord(data);
+			if (!service) {
+				error = 'Invalid service payload';
+			}
+		} catch (e) {
+			error = e instanceof ApiError ? e.message : String(e);
+			raw = null;
+			service = null;
+		} finally {
+			loading = false;
+		}
+	}
+
+	$effect(() => {
+		const id = serviceId;
+		if (!id) return;
+		void refresh();
+	});
+
+	const ctx: ServiceContextValue = {
+		get id() {
+			return serviceId;
+		},
+		get service() {
+			return service;
+		},
+		get raw() {
+			return raw;
+		},
+		get loading() {
+			return loading;
+		},
+		get error() {
+			return error;
+		},
+		refresh
+	};
+
+	setContext(SERVICE_CONTEXT_KEY, ctx);
+
+	function subNavClass(href: string, exact: boolean): string {
+		const path = page.url.pathname;
+		const active = exact ? path === href : path === href || path.startsWith(href + '/');
+		return cn(
+			'rounded-lg px-3 py-2 text-sm transition-colors',
+			active
+				? 'bg-primary/10 font-medium text-primary'
+				: 'text-muted-foreground hover:bg-muted hover:text-foreground'
+		);
+	}
+
+	async function onDelete() {
+		if (!serviceId || !confirm('Delete this service?')) return;
+		try {
+			await apiClient().deleteService(serviceId);
+			goto('/services');
+		} catch (e) {
+			error = e instanceof ApiError ? e.message : String(e);
+		}
+	}
+</script>
+
+<p class="mb-4">
+	<a href="/services" class="text-primary text-sm hover:underline">← Services</a>
+</p>
+
+<div class="mb-4 flex flex-wrap items-start justify-between gap-4">
+	<div class="min-w-0">
+		{#if loading}
+			<h2 class="text-xl font-semibold tracking-tight">Service …</h2>
+		{:else if service}
+			<h2 class="text-xl font-semibold tracking-tight">
+				{service.name}
+				<span class="text-muted-foreground font-normal">:{service.version}</span>
+			</h2>
+			<p class="text-muted-foreground mt-1 text-sm">
+				<code class="text-xs">{service.id}</code>
+				{#if service.organizationId}
+					· org <code class="text-xs">{service.organizationId}</code>
+				{/if}
+				· {service.type}
+			</p>
+		{:else}
+			<h2 class="text-xl font-semibold tracking-tight">Service {serviceId}</h2>
+		{/if}
+	</div>
+	<Button variant="destructive" size="sm" disabled={loading} onclick={() => void onDelete()}>
+		Delete service
+	</Button>
+</div>
+
+{#if error}
+	<div class="mb-4">
+		<ApiErrorAlert message={error} />
+	</div>
+{/if}
+
+<nav class="border-border mb-6 flex flex-wrap gap-1 border-b pb-3">
+	{#each subNav as item (item.label)}
+		{@const href = item.href(serviceId)}
+		<a href={href} class={subNavClass(href, item.exact ?? false)}>{item.label}</a>
+	{/each}
+</nav>
+
+{@render children()}

--- a/web-ui/src/routes/(app)/services/[id]/+layout.svelte
+++ b/web-ui/src/routes/(app)/services/[id]/+layout.svelte
@@ -1,3 +1,19 @@
+<!--
+  ~ Copyright The Reshapr Authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
 <script lang="ts">
 	import { goto } from '$app/navigation';
 	import { page } from '$app/state';

--- a/web-ui/src/routes/(app)/services/[id]/+page.svelte
+++ b/web-ui/src/routes/(app)/services/[id]/+page.svelte
@@ -1,3 +1,19 @@
+<!--
+  ~ Copyright The Reshapr Authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
 <script lang="ts">
 	import { getContext } from 'svelte';
 	import { apiClient } from '$lib/api/client.js';

--- a/web-ui/src/routes/(app)/services/[id]/+page.svelte
+++ b/web-ui/src/routes/(app)/services/[id]/+page.svelte
@@ -1,0 +1,161 @@
+<script lang="ts">
+	import { getContext } from 'svelte';
+	import { apiClient } from '$lib/api/client.js';
+	import JsonBlock from '$lib/components/JsonBlock.svelte';
+	import { loadServiceHubSummary, type ServiceHubSummary } from '$lib/serviceHub.js';
+	import { SERVICE_CONTEXT_KEY, type ServiceContextValue } from '$lib/serviceContext.js';
+	import * as Card from '$lib/components/ui/card/index.js';
+	import * as Collapsible from '$lib/components/ui/collapsible/index.js';
+	import { Button } from '$lib/components/ui/button/index.js';
+	import { cn } from '$lib/utils.js';
+	import ChevronDownIcon from '@lucide/svelte/icons/chevron-down';
+
+	const ctx = getContext<ServiceContextValue>(SERVICE_CONTEXT_KEY);
+
+	let payloadOpen = $state(false);
+	let summary = $state<ServiceHubSummary | null>(null);
+	let summaryError = $state<string | null>(null);
+	let summaryLoading = $state(false);
+
+	async function loadSummary() {
+		if (!ctx.id) return;
+		summaryLoading = true;
+		summaryError = null;
+		try {
+			summary = await loadServiceHubSummary(ctx.id, apiClient());
+		} catch (e) {
+			summary = null;
+			summaryError = e instanceof Error ? e.message : String(e);
+		} finally {
+			summaryLoading = false;
+		}
+	}
+
+	$effect(() => {
+		if (ctx.id && !ctx.loading && ctx.service) {
+			void loadSummary();
+		}
+	});
+
+	function fmtCount(n: number | null | undefined): string {
+		if (summaryLoading) return '…';
+		if (n == null) return '—';
+		return String(n);
+	}
+</script>
+
+{#if summaryError}
+	<p class="text-destructive mb-4 text-sm">{summaryError}</p>
+{/if}
+
+<div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+	<Card.Root>
+		<Card.Header class="pb-2">
+			<Card.Title class="text-sm font-medium">Artifacts</Card.Title>
+		</Card.Header>
+		<Card.Content>
+			<p class="text-3xl font-bold tracking-tight">{fmtCount(summary?.artifactCount)}</p>
+			<Button variant="link" class="mt-2 h-auto p-0 text-xs" href="/services/{ctx.id}/artifacts">
+				View artifacts
+			</Button>
+		</Card.Content>
+	</Card.Root>
+
+	<Card.Root>
+		<Card.Header class="pb-2">
+			<Card.Title class="text-sm font-medium">Configuration plans</Card.Title>
+		</Card.Header>
+		<Card.Content>
+			<p class="text-3xl font-bold tracking-tight">{fmtCount(summary?.planCount)}</p>
+			<Button variant="link" class="mt-2 h-auto p-0 text-xs" href="/services/{ctx.id}/plans">
+				View plans
+			</Button>
+		</Card.Content>
+	</Card.Root>
+
+	<Card.Root>
+		<Card.Header class="pb-2">
+			<Card.Title class="text-sm font-medium">Expositions</Card.Title>
+		</Card.Header>
+		<Card.Content>
+			<p class="text-3xl font-bold tracking-tight">
+				{fmtCount(summary?.expositionActiveCount)}
+				<span class="text-muted-foreground text-lg font-normal">
+					/ {fmtCount(summary?.expositionAllCount)} total
+				</span>
+			</p>
+			<p class="text-muted-foreground text-xs">Active / all</p>
+			<Button variant="link" class="mt-2 h-auto p-0 text-xs" href="/services/{ctx.id}/expositions">
+				View expositions
+			</Button>
+		</Card.Content>
+	</Card.Root>
+
+	<Card.Root>
+		<Card.Header class="pb-2">
+			<Card.Title class="text-sm font-medium">MCP custom tools</Card.Title>
+		</Card.Header>
+		<Card.Content>
+			<p class="text-3xl font-bold tracking-tight">{fmtCount(summary?.mcpCustomToolsCount)}</p>
+			<Button
+				variant="link"
+				class="mt-2 h-auto p-0 text-xs"
+				href="/services/{ctx.id}/mcp-custom-tools"
+			>
+				View tools
+			</Button>
+		</Card.Content>
+	</Card.Root>
+
+	<Card.Root>
+		<Card.Header class="pb-2">
+			<Card.Title class="text-sm font-medium">MCP prompts</Card.Title>
+		</Card.Header>
+		<Card.Content>
+			<p class="text-3xl font-bold tracking-tight">{fmtCount(summary?.mcpPromptsCount)}</p>
+			<Button variant="link" class="mt-2 h-auto p-0 text-xs" href="/services/{ctx.id}/mcp-prompts">
+				View prompts
+			</Button>
+		</Card.Content>
+	</Card.Root>
+
+	<Card.Root>
+		<Card.Header class="pb-2">
+			<Card.Title class="text-sm font-medium">MCP endpoints</Card.Title>
+		</Card.Header>
+		<Card.Content>
+			<p class="text-3xl font-bold tracking-tight">{fmtCount(summary?.mcpUrlCount)}</p>
+			<p class="text-muted-foreground text-xs">From active expositions</p>
+		</Card.Content>
+	</Card.Root>
+
+	{#if ctx.service}
+		<Card.Root>
+			<Card.Header class="pb-2">
+				<Card.Title class="text-sm font-medium">API operations</Card.Title>
+			</Card.Header>
+			<Card.Content>
+				<p class="text-3xl font-bold tracking-tight">{ctx.service.operationsCount}</p>
+				<p class="text-muted-foreground text-xs">Registered on service</p>
+			</Card.Content>
+		</Card.Root>
+	{/if}
+</div>
+
+<Collapsible.Root bind:open={payloadOpen} class="mt-8 rounded-lg border">
+	<Collapsible.Trigger
+		class="flex w-full items-center justify-between gap-3 px-4 py-3 text-left text-sm font-semibold transition-colors hover:bg-muted/50"
+		type="button"
+	>
+		<span>Service payload</span>
+		<ChevronDownIcon
+			class={cn(
+				'text-muted-foreground size-4 shrink-0 transition-transform duration-200',
+				payloadOpen && 'rotate-180'
+			)}
+		/>
+	</Collapsible.Trigger>
+	<Collapsible.Content class="border-t px-4 pb-4 pt-3">
+		<JsonBlock value={ctx.raw} loading={ctx.loading} />
+	</Collapsible.Content>
+</Collapsible.Root>

--- a/web-ui/src/routes/(app)/services/[id]/+page.ts
+++ b/web-ui/src/routes/(app)/services/[id]/+page.ts
@@ -1,0 +1,1 @@
+export const prerender = false;

--- a/web-ui/src/routes/(app)/services/[id]/+page.ts
+++ b/web-ui/src/routes/(app)/services/[id]/+page.ts
@@ -1,1 +1,17 @@
+/*
+ * Copyright The Reshapr Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 export const prerender = false;

--- a/web-ui/src/routes/(app)/services/[id]/artifacts/+page.svelte
+++ b/web-ui/src/routes/(app)/services/[id]/artifacts/+page.svelte
@@ -1,0 +1,53 @@
+<script lang="ts">
+	import { getContext } from 'svelte';
+	import { apiClient, ApiError } from '$lib/api/client.js';
+	import ApiErrorAlert from '$lib/components/ApiErrorAlert.svelte';
+	import JsonBlock from '$lib/components/JsonBlock.svelte';
+	import { SERVICE_CONTEXT_KEY, type ServiceContextValue } from '$lib/serviceContext.js';
+	import { Button } from '$lib/components/ui/button/index.js';
+
+	const ctx = getContext<ServiceContextValue>(SERVICE_CONTEXT_KEY);
+
+	let data = $state<unknown[]>([]);
+	let error = $state<string | null>(null);
+	let loading = $state(true);
+
+	async function load() {
+		if (!ctx.id) return;
+		loading = true;
+		error = null;
+		try {
+			const list = await apiClient().listArtifactsByService(ctx.id);
+			data = Array.isArray(list) ? list : [];
+		} catch (e) {
+			error = e instanceof ApiError ? e.message : String(e);
+			data = [];
+		} finally {
+			loading = false;
+		}
+	}
+
+	$effect(() => {
+		if (ctx.id && !ctx.loading) void load();
+	});
+</script>
+
+<div class="mb-4 flex items-center justify-between gap-4">
+	<h3 class="text-lg font-semibold">Artifacts</h3>
+	<Button variant="outline" size="sm" disabled={loading} onclick={() => void load()}>Refresh</Button>
+</div>
+
+<p class="text-muted-foreground mb-4 text-sm">
+	Import and attach flows are available under
+	<a href="/artifacts" class="text-primary hover:underline">Experimental → Artifacts</a>.
+</p>
+
+{#if error}
+	<ApiErrorAlert message={error} />
+{/if}
+
+<JsonBlock value={data} {loading} />
+
+{#if !loading && !error && data.length === 0}
+	<p class="text-muted-foreground mt-4 text-sm">No artifacts for this service.</p>
+{/if}

--- a/web-ui/src/routes/(app)/services/[id]/artifacts/+page.svelte
+++ b/web-ui/src/routes/(app)/services/[id]/artifacts/+page.svelte
@@ -1,3 +1,19 @@
+<!--
+  ~ Copyright The Reshapr Authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
 <script lang="ts">
 	import { getContext } from 'svelte';
 	import { apiClient, ApiError } from '$lib/api/client.js';

--- a/web-ui/src/routes/(app)/services/[id]/expositions/+page.svelte
+++ b/web-ui/src/routes/(app)/services/[id]/expositions/+page.svelte
@@ -1,0 +1,135 @@
+<script lang="ts">
+	import { getContext } from 'svelte';
+	import { apiClient, ApiError } from '$lib/api/client.js';
+	import ApiErrorAlert from '$lib/components/ApiErrorAlert.svelte';
+	import { collectMcpUrlsFromActiveExpositions } from '$lib/mcpEndpointUrls.js';
+	import { expositionBelongsToService } from '$lib/serviceHub.js';
+	import { SERVICE_CONTEXT_KEY, type ServiceContextValue } from '$lib/serviceContext.js';
+	import { Button } from '$lib/components/ui/button/index.js';
+	import * as Table from '$lib/components/ui/table/index.js';
+
+	const ctx = getContext<ServiceContextValue>(SERVICE_CONTEXT_KEY);
+
+	type ExpoRow = {
+		id: string;
+		scope: string;
+		backend: string;
+		mcpUrls: number;
+	};
+
+	let rows = $state<ExpoRow[]>([]);
+	let error = $state<string | null>(null);
+	let loading = $state(true);
+	let mode = $state<'active' | 'all'>('active');
+
+	function backendUrl(configurationPlan: unknown): string {
+		if (!configurationPlan || typeof configurationPlan !== 'object') return '—';
+		const c = configurationPlan as Record<string, unknown>;
+		return typeof c.backendEndpoint === 'string' ? c.backendEndpoint : '—';
+	}
+
+	function toRow(raw: unknown, scope: string): ExpoRow | null {
+		if (!raw || typeof raw !== 'object') return null;
+		const o = raw as Record<string, unknown>;
+		if (typeof o.id !== 'string') return null;
+		const urls = collectMcpUrlsFromActiveExpositions(
+			scope === 'active' ? [raw] : raw,
+		);
+		return {
+			id: o.id,
+			scope,
+			backend: backendUrl(o.configurationPlan),
+			mcpUrls: scope === 'active' ? urls.length : 0
+		};
+	}
+
+	async function load() {
+		if (!ctx.id) return;
+		loading = true;
+		error = null;
+		try {
+			const c = apiClient();
+			if (mode === 'active') {
+				const active = await c.listExpositionsActive();
+				const list = (Array.isArray(active) ? active : []).filter((e) =>
+					expositionBelongsToService(e, ctx.id),
+				);
+				rows = list
+					.map((e) => toRow(e, 'active'))
+					.filter((r): r is ExpoRow => r != null);
+			} else {
+				const all = await c.listExpositionsAll();
+				const list = (Array.isArray(all) ? all : []).filter((e) =>
+					expositionBelongsToService(e, ctx.id),
+				);
+				rows = list
+					.map((e) => toRow(e, 'all'))
+					.filter((r): r is ExpoRow => r != null);
+			}
+		} catch (e) {
+			error = e instanceof ApiError ? e.message : String(e);
+			rows = [];
+		} finally {
+			loading = false;
+		}
+	}
+
+	$effect(() => {
+		mode;
+		if (ctx.id && !ctx.loading) void load();
+	});
+</script>
+
+<div class="mb-4 flex flex-wrap items-center justify-between gap-4">
+	<h3 class="text-lg font-semibold">Expositions</h3>
+	<div class="flex flex-wrap items-center gap-2">
+		<label class="flex items-center gap-2 text-sm">
+			<input type="radio" bind:group={mode} value="active" />
+			Active
+		</label>
+		<label class="flex items-center gap-2 text-sm">
+			<input type="radio" bind:group={mode} value="all" />
+			All
+		</label>
+		<Button variant="outline" size="sm" disabled={loading} onclick={() => void load()}>Refresh</Button>
+	</div>
+</div>
+
+{#if error}
+	<ApiErrorAlert message={error} />
+{/if}
+
+<div class="rounded-lg border">
+	<Table.Root>
+		<Table.Header>
+			<Table.Row>
+				<Table.Head>ID</Table.Head>
+				<Table.Head>Scope</Table.Head>
+				<Table.Head>Backend</Table.Head>
+				<Table.Head>MCP URLs</Table.Head>
+			</Table.Row>
+		</Table.Header>
+		<Table.Body>
+			{#if loading}
+				<Table.Row>
+					<Table.Cell colspan={4} class="text-muted-foreground">Loading…</Table.Cell>
+				</Table.Row>
+			{:else if rows.length === 0}
+				<Table.Row>
+					<Table.Cell colspan={4} class="text-muted-foreground">No expositions for this service.</Table.Cell>
+				</Table.Row>
+			{:else}
+				{#each rows as e (e.id + e.scope)}
+					<Table.Row>
+						<Table.Cell>
+							<a href="/expositions/{e.id}" class="text-primary hover:underline">{e.id}</a>
+						</Table.Cell>
+						<Table.Cell>{e.scope}</Table.Cell>
+						<Table.Cell class="max-w-xs truncate" title={e.backend}>{e.backend}</Table.Cell>
+						<Table.Cell>{e.mcpUrls || '—'}</Table.Cell>
+					</Table.Row>
+				{/each}
+			{/if}
+		</Table.Body>
+	</Table.Root>
+</div>

--- a/web-ui/src/routes/(app)/services/[id]/expositions/+page.svelte
+++ b/web-ui/src/routes/(app)/services/[id]/expositions/+page.svelte
@@ -1,3 +1,19 @@
+<!--
+  ~ Copyright The Reshapr Authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
 <script lang="ts">
 	import { getContext } from 'svelte';
 	import { apiClient, ApiError } from '$lib/api/client.js';

--- a/web-ui/src/routes/(app)/services/[id]/mcp-custom-tools/+page.svelte
+++ b/web-ui/src/routes/(app)/services/[id]/mcp-custom-tools/+page.svelte
@@ -1,0 +1,128 @@
+<script lang="ts">
+	import { getContext } from 'svelte';
+	import { apiClient, ApiError } from '$lib/api/client.js';
+	import ApiErrorAlert from '$lib/components/ApiErrorAlert.svelte';
+	import ScrollableCode from '$lib/components/ScrollableCode.svelte';
+	import {
+		resolveMcpCustomToolsForService,
+		type McpCustomToolsResolution
+	} from '$lib/mcpCustomTools.js';
+	import { collectMcpUrlsFromActiveExpositions } from '$lib/mcpEndpointUrls.js';
+	import { expositionBelongsToService } from '$lib/serviceHub.js';
+	import { SERVICE_CONTEXT_KEY, type ServiceContextValue } from '$lib/serviceContext.js';
+	import { Badge } from '$lib/components/ui/badge/index.js';
+	import { Button } from '$lib/components/ui/button/index.js';
+	import * as Card from '$lib/components/ui/card/index.js';
+	import * as Collapsible from '$lib/components/ui/collapsible/index.js';
+	import * as Table from '$lib/components/ui/table/index.js';
+
+	const ctx = getContext<ServiceContextValue>(SERVICE_CONTEXT_KEY);
+
+	let result = $state<McpCustomToolsResolution | null>(null);
+	let mcpUrls = $state<{ url: string; fqdn: string }[]>([]);
+	let error = $state<string | null>(null);
+	let loading = $state(false);
+	let yamlOpen = $state(false);
+
+	const tools = $derived(result?.tools ?? []);
+
+	async function load() {
+		if (!ctx.id) return;
+		loading = true;
+		error = null;
+		result = null;
+		try {
+			const c = apiClient();
+			const active = await c.listExpositionsActive();
+			const forService = (Array.isArray(active) ? active : []).filter((e) =>
+				expositionBelongsToService(e, ctx.id),
+			);
+			mcpUrls = collectMcpUrlsFromActiveExpositions(forService).map((u) => ({
+				url: u.url,
+				fqdn: u.fqdn
+			}));
+			result = await resolveMcpCustomToolsForService(ctx.id, c);
+			yamlOpen = Boolean(result.artifactYaml);
+		} catch (e) {
+			error = e instanceof ApiError ? e.message : String(e);
+		} finally {
+			loading = false;
+		}
+	}
+
+	$effect(() => {
+		if (ctx.id && !ctx.loading) void load();
+	});
+</script>
+
+<div class="mb-4 flex items-center justify-between gap-4">
+	<h3 class="text-lg font-semibold">MCP custom tools</h3>
+	<Button variant="outline" size="sm" disabled={loading} onclick={() => void load()}>Refresh</Button>
+</div>
+
+{#if error}
+	<ApiErrorAlert message={error} />
+{/if}
+
+{#if result}
+	<div class="text-muted-foreground mb-4 flex flex-wrap items-center gap-2 text-sm">
+		<Badge variant="secondary">{result.source}</Badge>
+		{#if result.expoId}
+			<span>Exposition <code class="text-xs">{result.expoId}</code></span>
+		{/if}
+		<span>{tools.length} tool(s)</span>
+	</div>
+{/if}
+
+{#if mcpUrls.length > 0}
+	<Card.Root class="mb-6">
+		<Card.Header>
+			<Card.Title class="text-base">MCP endpoints</Card.Title>
+		</Card.Header>
+		<Card.Content class="space-y-2">
+			{#each mcpUrls as u (u.url)}
+				<ScrollableCode text={u.url} maxHeight="3rem" />
+			{/each}
+		</Card.Content>
+	</Card.Root>
+{/if}
+
+{#if result?.artifactYaml}
+	<Collapsible.Root bind:open={yamlOpen} class="mb-6">
+		<Collapsible.Trigger class="text-primary text-sm font-medium hover:underline" type="button">
+			{yamlOpen ? 'Hide' : 'Show'} RESHAPR_CUSTOM_TOOLS YAML
+		</Collapsible.Trigger>
+		<Collapsible.Content class="mt-2">
+			<ScrollableCode text={result.artifactYaml} maxHeight="24rem" />
+		</Collapsible.Content>
+	</Collapsible.Root>
+{/if}
+
+<div class="rounded-lg border">
+	<Table.Root>
+		<Table.Header>
+			<Table.Row>
+				<Table.Head>Name</Table.Head>
+				<Table.Head>Description</Table.Head>
+			</Table.Row>
+		</Table.Header>
+		<Table.Body>
+			{#if loading}
+				<Table.Row>
+					<Table.Cell colspan={2} class="text-muted-foreground">Loading…</Table.Cell>
+				</Table.Row>
+			{:else if tools.length === 0}
+				<Table.Row>
+					<Table.Cell colspan={2} class="text-muted-foreground">No custom tools resolved.</Table.Cell>
+				</Table.Row>
+			{:else}
+				{#each tools as t (t.name)}
+					<Table.Row>
+						<Table.Cell class="font-mono text-sm">{t.name}</Table.Cell>
+						<Table.Cell class="text-sm">{t.description || '—'}</Table.Cell>
+					</Table.Row>
+				{/each}
+			{/if}
+		</Table.Body>
+	</Table.Root>
+</div>

--- a/web-ui/src/routes/(app)/services/[id]/mcp-custom-tools/+page.svelte
+++ b/web-ui/src/routes/(app)/services/[id]/mcp-custom-tools/+page.svelte
@@ -1,3 +1,19 @@
+<!--
+  ~ Copyright The Reshapr Authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
 <script lang="ts">
 	import { getContext } from 'svelte';
 	import { apiClient, ApiError } from '$lib/api/client.js';

--- a/web-ui/src/routes/(app)/services/[id]/mcp-prompts/+page.svelte
+++ b/web-ui/src/routes/(app)/services/[id]/mcp-prompts/+page.svelte
@@ -1,0 +1,126 @@
+<script lang="ts">
+	import { getContext } from 'svelte';
+	import { apiClient, ApiError } from '$lib/api/client.js';
+	import ApiErrorAlert from '$lib/components/ApiErrorAlert.svelte';
+	import ScrollableCode from '$lib/components/ScrollableCode.svelte';
+	import { resolveMcpPromptsForService, type McpPromptsResolution } from '$lib/mcpPrompts.js';
+	import { SERVICE_CONTEXT_KEY, type ServiceContextValue } from '$lib/serviceContext.js';
+	import { Badge } from '$lib/components/ui/badge/index.js';
+	import { Button } from '$lib/components/ui/button/index.js';
+	import * as Card from '$lib/components/ui/card/index.js';
+	import * as Collapsible from '$lib/components/ui/collapsible/index.js';
+	import * as Table from '$lib/components/ui/table/index.js';
+
+	const ctx = getContext<ServiceContextValue>(SERVICE_CONTEXT_KEY);
+
+	let result = $state<McpPromptsResolution | null>(null);
+	let error = $state<string | null>(null);
+	let loading = $state(false);
+	let yamlOpen = $state(false);
+
+	const prompts = $derived(result?.prompts ?? []);
+
+	function formatArguments(
+		args: { name: string; description?: string; required?: boolean }[] | undefined,
+	): string {
+		if (!args?.length) return '—';
+		return args
+			.map((a) => {
+				const bits = [a.name];
+				if (a.required) bits.push('required');
+				if (a.description) bits.push(a.description);
+				return bits.join(' — ');
+			})
+			.join('; ');
+	}
+
+	async function load() {
+		if (!ctx.id) return;
+		loading = true;
+		error = null;
+		result = null;
+		try {
+			result = await resolveMcpPromptsForService(ctx.id, apiClient());
+			yamlOpen = result.artifactYamls.length > 0;
+		} catch (e) {
+			error = e instanceof ApiError ? e.message : String(e);
+		} finally {
+			loading = false;
+		}
+	}
+
+	$effect(() => {
+		if (ctx.id && !ctx.loading) void load();
+	});
+</script>
+
+<div class="mb-4 flex items-center justify-between gap-4">
+	<h3 class="text-lg font-semibold">MCP prompts</h3>
+	<Button variant="outline" size="sm" disabled={loading} onclick={() => void load()}>Refresh</Button>
+</div>
+
+<p class="text-muted-foreground mb-4 text-sm">
+	Resolved from <code class="text-xs">RESHAPR_PROMPTS</code> artifacts on this service. Attach prompts via
+	<a href="/artifacts" class="text-primary hover:underline">Artifacts</a>.
+</p>
+
+{#if error}
+	<ApiErrorAlert message={error} />
+{/if}
+
+{#if result}
+	<div class="text-muted-foreground mb-4 flex flex-wrap items-center gap-2 text-sm">
+		<Badge variant="secondary">{result.source}</Badge>
+		<span>{prompts.length} prompt(s)</span>
+		{#if result.artifactNames.length}
+			<span>Artifacts: {result.artifactNames.join(', ')}</span>
+		{/if}
+	</div>
+{/if}
+
+{#if result && result.artifactYamls.length > 0}
+	<Collapsible.Root bind:open={yamlOpen} class="mb-6">
+		<Collapsible.Trigger class="text-primary text-sm font-medium hover:underline" type="button">
+			{yamlOpen ? 'Hide' : 'Show'} artifact YAML
+		</Collapsible.Trigger>
+		<Collapsible.Content class="mt-2 space-y-4">
+			{#each result.artifactYamls as art (art.name)}
+				<div>
+					<p class="mb-1 text-sm font-medium">{art.name}</p>
+					<ScrollableCode text={art.content} maxHeight="16rem" />
+				</div>
+			{/each}
+		</Collapsible.Content>
+	</Collapsible.Root>
+{/if}
+
+<div class="rounded-lg border">
+	<Table.Root>
+		<Table.Header>
+			<Table.Row>
+				<Table.Head>Name</Table.Head>
+				<Table.Head>Description</Table.Head>
+				<Table.Head>Arguments</Table.Head>
+			</Table.Row>
+		</Table.Header>
+		<Table.Body>
+			{#if loading}
+				<Table.Row>
+					<Table.Cell colspan={3} class="text-muted-foreground">Loading…</Table.Cell>
+				</Table.Row>
+			{:else if prompts.length === 0}
+				<Table.Row>
+					<Table.Cell colspan={3} class="text-muted-foreground">No prompts.</Table.Cell>
+				</Table.Row>
+			{:else}
+				{#each prompts as p (p.name)}
+					<Table.Row>
+						<Table.Cell class="font-mono text-sm">{p.name}</Table.Cell>
+						<Table.Cell class="text-sm">{p.description ?? '—'}</Table.Cell>
+						<Table.Cell class="text-sm">{formatArguments(p.arguments)}</Table.Cell>
+					</Table.Row>
+				{/each}
+			{/if}
+		</Table.Body>
+	</Table.Root>
+</div>

--- a/web-ui/src/routes/(app)/services/[id]/mcp-prompts/+page.svelte
+++ b/web-ui/src/routes/(app)/services/[id]/mcp-prompts/+page.svelte
@@ -1,3 +1,19 @@
+<!--
+  ~ Copyright The Reshapr Authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
 <script lang="ts">
 	import { getContext } from 'svelte';
 	import { apiClient, ApiError } from '$lib/api/client.js';

--- a/web-ui/src/routes/(app)/services/[id]/plans/+page.svelte
+++ b/web-ui/src/routes/(app)/services/[id]/plans/+page.svelte
@@ -1,0 +1,96 @@
+<script lang="ts">
+	import { getContext } from 'svelte';
+	import { apiClient, ApiError } from '$lib/api/client.js';
+	import ApiErrorAlert from '$lib/components/ApiErrorAlert.svelte';
+	import { planBelongsToService } from '$lib/serviceHub.js';
+	import { SERVICE_CONTEXT_KEY, type ServiceContextValue } from '$lib/serviceContext.js';
+	import { Button } from '$lib/components/ui/button/index.js';
+	import * as Table from '$lib/components/ui/table/index.js';
+
+	const ctx = getContext<ServiceContextValue>(SERVICE_CONTEXT_KEY);
+
+	type PlanRow = {
+		id: string;
+		name: string;
+		backendEndpoint: string;
+	};
+
+	let rows = $state<PlanRow[]>([]);
+	let error = $state<string | null>(null);
+	let loading = $state(true);
+
+	function toRow(raw: unknown): PlanRow | null {
+		if (!raw || typeof raw !== 'object') return null;
+		const o = raw as Record<string, unknown>;
+		if (typeof o.id !== 'string') return null;
+		return {
+			id: o.id,
+			name: typeof o.name === 'string' ? o.name : '—',
+			backendEndpoint: typeof o.backendEndpoint === 'string' ? o.backendEndpoint : '—'
+		};
+	}
+
+	async function load() {
+		if (!ctx.id) return;
+		loading = true;
+		error = null;
+		try {
+			const all = await apiClient().listConfigurationPlans();
+			const list = (Array.isArray(all) ? all : []).filter((p) => planBelongsToService(p, ctx.id));
+			rows = list.map(toRow).filter((r): r is PlanRow => r != null);
+		} catch (e) {
+			error = e instanceof ApiError ? e.message : String(e);
+			rows = [];
+		} finally {
+			loading = false;
+		}
+	}
+
+	$effect(() => {
+		if (ctx.id && !ctx.loading) void load();
+	});
+</script>
+
+<div class="mb-4 flex flex-wrap items-center justify-between gap-4">
+	<h3 class="text-lg font-semibold">Configuration plans</h3>
+	<Button variant="outline" size="sm" disabled={loading} onclick={() => void load()}>Refresh</Button>
+</div>
+
+{#if error}
+	<ApiErrorAlert message={error} />
+{/if}
+
+<div class="rounded-lg border">
+	<Table.Root>
+		<Table.Header>
+			<Table.Row>
+				<Table.Head>ID</Table.Head>
+				<Table.Head>Name</Table.Head>
+				<Table.Head>Backend</Table.Head>
+			</Table.Row>
+		</Table.Header>
+		<Table.Body>
+			{#if loading}
+				<Table.Row>
+					<Table.Cell colspan={3} class="text-muted-foreground">Loading…</Table.Cell>
+				</Table.Row>
+			{:else if rows.length === 0}
+				<Table.Row>
+					<Table.Cell colspan={3} class="text-muted-foreground">No plans for this service.</Table.Cell>
+				</Table.Row>
+			{:else}
+				{#each rows as p (p.id)}
+					<Table.Row>
+						<Table.Cell>
+							<a href="/plans/{p.id}" class="text-primary hover:underline">{p.id}</a>
+						</Table.Cell>
+						<Table.Cell>{p.name}</Table.Cell>
+						<Table.Cell class="max-w-xs truncate" title={p.backendEndpoint}>
+							{p.backendEndpoint}
+						</Table.Cell>
+					</Table.Row>
+				{/each}
+			{/if}
+		</Table.Body>
+	</Table.Root>
+</div>

--- a/web-ui/src/routes/(app)/services/[id]/plans/+page.svelte
+++ b/web-ui/src/routes/(app)/services/[id]/plans/+page.svelte
@@ -1,3 +1,19 @@
+<!--
+  ~ Copyright The Reshapr Authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
 <script lang="ts">
 	import { getContext } from 'svelte';
 	import { apiClient, ApiError } from '$lib/api/client.js';

--- a/web-ui/src/routes/api/auth/session/+server.ts
+++ b/web-ui/src/routes/api/auth/session/+server.ts
@@ -15,7 +15,7 @@
  */
 
 import { json } from '@sveltejs/kit';
-import { getSessionToken, extractUserProfile, decodeJwtPayload } from '$lib/server/auth.js';
+import { getSessionToken, extractUserProfile, extractSessionClaims, decodeJwtPayload } from '$lib/server/auth.js';
 import type { RequestHandler } from './$types.js';
 
 /**
@@ -52,7 +52,8 @@ export const GET: RequestHandler = async ({ cookies }) => {
     username: profile.username,
     email: profile.email,
     org: profile.org,
-    isAdmin: profile.org === 'reshapr'
+    isAdmin: profile.org === 'reshapr',
+    ...extractSessionClaims(token)
   });
 };
 


### PR DESCRIPTION
## Summary

Import operator-facing UI from `reshapr-ui-control` into `web-ui`, adapted to the existing BFF architecture (httpOnly session cookie, SvelteKit proxies `/api/v1/*` and `/api/admin/*`).

**Step 1**
- Dashboard with org-scoped stats (services, gateways, quotas, expositions)
- Services list and service hub (`/services/[id]/*`: overview, artifacts, plans, expositions, MCP tools/prompts)
- Account page (session profile, groups, roles, expiry)
- Shared API client, domain modules (dashboard stats, service hub, MCP resolution), and UI building blocks (`PageHeader`, `ApiErrorAlert`, `JsonBlock`, etc.)
- Session endpoint enriched with JWT display claims (groups, roles, expiration)

**Experimental**
- Global operator screens: artifacts, plans, expositions, secrets, gateway groups, quotas, API tokens, MCP custom tools/prompts
- Collapsible **Experimental** section in the sidebar (lab flask icon)
- Full REST client methods for CRUD and artifact uploads via the BFF proxy

**Architecture**
- Keeps BFF pattern: no Bearer token or control-plane URL in the browser
- Proxy forwards request bodies as streams (FormData-ready for artifact import)
- Existing admin organizations/users flow unchanged

## Test plan

- [ ] Start control plane locally (`:5555`) and `web-ui` (`npm run dev` in `web-ui/`)
- [ ] Login (on-prem and/or OIDC if configured)
- [ ] Dashboard: stats load and refresh
- [ ] Services → open a service hub → navigate sub-pages
- [ ] Account: profile, org, session expiry displayed
- [ ] Experimental: open each sidebar entry (artifacts, plans, expositions, etc.)
- [ ] From service hub, click plan/exposition IDs → detail pages load (no 404)
- [ ] Admin organizations still works for `reshapr` org users
- [ ] `npm run check` and `npm run build` pass in `web-ui/`

Addresses #184