### PR TITLE
feat(web-ui): Artifacts hub and read-only YamlMonacoEditor (release 1+2)

### DIFF
--- a/web-ui/package-lock.json
+++ b/web-ui/package-lock.json
@@ -14,6 +14,8 @@
         "@sveltejs/kit": "2.61.1",
         "bits-ui": "2.18.1",
         "clsx": "2.1.1",
+        "monaco-editor": "^0.55.1",
+        "monaco-yaml": "^5.5.1",
         "svelte": "5.55.9",
         "tailwind-merge": "3.6.0",
         "tailwind-variants": "3.2.2",
@@ -1311,6 +1313,12 @@
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "license": "MIT"
     },
+    "node_modules/@vscode/l10n": {
+      "version": "0.0.18",
+      "resolved": "https://registry.npmjs.org/@vscode/l10n/-/l10n-0.0.18.tgz",
+      "integrity": "sha512-KYSIHVmslkaCDyw013pphY+d7x1qV8IZupYfeIfzNA+nsaWHbn5uPuQRvdRFsa9zFzGeudPuoGoZ1Op4jrJXIQ==",
+      "license": "MIT"
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -1438,6 +1446,15 @@
       "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.8.1.tgz",
       "integrity": "sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw==",
       "license": "MIT"
+    },
+    "node_modules/dompurify": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.7.tgz",
+      "integrity": "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
     },
     "node_modules/enhanced-resolve": {
       "version": "5.22.0",
@@ -1602,6 +1619,12 @@
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
+    },
+    "node_modules/jsonc-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+      "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
+      "license": "MIT"
     },
     "node_modules/kleur": {
       "version": "4.1.5",
@@ -1885,6 +1908,102 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/marked": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-14.0.0.tgz",
+      "integrity": "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/monaco-editor": {
+      "version": "0.55.1",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.55.1.tgz",
+      "integrity": "sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==",
+      "license": "MIT",
+      "dependencies": {
+        "dompurify": "3.2.7",
+        "marked": "14.0.0"
+      }
+    },
+    "node_modules/monaco-languageserver-types": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/monaco-languageserver-types/-/monaco-languageserver-types-0.4.1.tgz",
+      "integrity": "sha512-uLiYM6K6jPqAa1ni9lRBoj8ZJAErOcegBrfEpurIUUO8cBhlhrGYjWbjhl4OPcxUNoj1JvqSETjwCTyhGgwymQ==",
+      "license": "MIT",
+      "dependencies": {
+        "monaco-types": "^0.1.0",
+        "vscode-languageserver-protocol": "^3.0.0",
+        "vscode-uri": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/remcohaszing"
+      }
+    },
+    "node_modules/monaco-marker-data-provider": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/monaco-marker-data-provider/-/monaco-marker-data-provider-1.2.5.tgz",
+      "integrity": "sha512-5ZdcYukhPwgYMCvlZ9H5uWs5jc23BQ8fFF5AhSIdrz5mvYLsqGZ58ZLxTv8rCX6+AxdJ8+vxg1HVSk+F2bLosg==",
+      "license": "MIT",
+      "dependencies": {
+        "monaco-types": "^0.1.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/remcohaszing"
+      }
+    },
+    "node_modules/monaco-types": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/monaco-types/-/monaco-types-0.1.2.tgz",
+      "integrity": "sha512-8LwfrlWXsedHwAL41xhXyqzPibS8IqPuIXr9NdORhonS495c2/wky+sI1PRLvMCuiI0nqC2NH1six9hdiRY4Xg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/remcohaszing"
+      }
+    },
+    "node_modules/monaco-worker-manager": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/monaco-worker-manager/-/monaco-worker-manager-2.0.1.tgz",
+      "integrity": "sha512-kdPL0yvg5qjhKPNVjJoym331PY/5JC11aPJXtCZNwWRvBr6jhkIamvYAyiY5P1AWFmNOy0aRDRoMdZfa71h8kg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "monaco-editor": ">=0.30.0"
+      }
+    },
+    "node_modules/monaco-yaml": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/monaco-yaml/-/monaco-yaml-5.5.1.tgz",
+      "integrity": "sha512-vLR1EoV7Au0tkuA9T6ZJr2q7CooRP69AvlqzWh9Gui6amuijdTsfCAQHtCFobRMwkhbuly6J1Q16NziTTiWtWQ==",
+      "license": "MIT",
+      "workspaces": [
+        "examples/*"
+      ],
+      "dependencies": {
+        "@vscode/l10n": "^0.0.18",
+        "jsonc-parser": "^3.0.0",
+        "monaco-languageserver-types": "^0.4.0",
+        "monaco-marker-data-provider": "^1.0.0",
+        "monaco-types": "^0.1.0",
+        "monaco-worker-manager": "^2.0.0",
+        "path-browserify": "^1.0.0",
+        "prettier": "^3.0.0",
+        "proxy-disposable": "^1.0.0",
+        "vscode-languageserver-textdocument": "^1.0.0",
+        "vscode-languageserver-types": "^3.0.0",
+        "vscode-uri": "^3.0.0",
+        "yaml": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/remcohaszing"
+      },
+      "peerDependencies": {
+        "monaco-editor": ">=0.36"
+      }
+    },
     "node_modules/mri": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
@@ -1930,6 +2049,12 @@
         "https://github.com/sponsors/sxzz",
         "https://opencollective.com/debug"
       ],
+      "license": "MIT"
+    },
+    "node_modules/path-browserify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
       "license": "MIT"
     },
     "node_modules/path-parse": {
@@ -1983,6 +2108,30 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.8.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.4.tgz",
+      "integrity": "sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==",
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/proxy-disposable": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/proxy-disposable/-/proxy-disposable-1.0.0.tgz",
+      "integrity": "sha512-Y673BKpFqk8XkYuoK9DGZ1RIzldz5SkzxTKc/+DkpaMdrDEbEalWlO/uMRMdJsXvdbTybJI26XDwN0KJpZDN4w==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/remcohaszing"
       }
     },
     "node_modules/readdirp": {
@@ -2484,6 +2633,58 @@
         "vite": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vscode-jsonrpc": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-9.0.0.tgz",
+      "integrity": "sha512-+VvMmQPJhtvJ+8O+zu2JKIRiLxXF8NW7krWgyMGeOHrp4Cn23T5hc0v2LknNeopDOB70wghHAds7mKtcZ0I4Sg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/vscode-languageserver-protocol": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.18.0.tgz",
+      "integrity": "sha512-Zdz+kJ12Iz6tc11xfZyEo501bBATHXrCjmMfnaR3pMnf1CoqZBKIynba3P+/bi9VEdrMbNtAVKYpKhbODvqy+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "vscode-jsonrpc": "9.0.0",
+        "vscode-languageserver-types": "3.18.0"
+      }
+    },
+    "node_modules/vscode-languageserver-textdocument": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
+      "integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==",
+      "license": "MIT"
+    },
+    "node_modules/vscode-languageserver-types": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.18.0.tgz",
+      "integrity": "sha512-8TsGPNMIMiiBdkORgRSvLjuiEIiAFtO+KssmYWxQ+uSVvlf7RjK8YKCOjPzZ+YA04jXEV7+7LvkSmHkhpNS99g==",
+      "license": "MIT"
+    },
+    "node_modules/vscode-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
+      "integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==",
+      "license": "MIT"
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/zimmerframe": {

--- a/web-ui/package.json
+++ b/web-ui/package.json
@@ -17,6 +17,8 @@
     "@sveltejs/kit": "2.61.1",
     "bits-ui": "2.18.1",
     "clsx": "2.1.1",
+    "monaco-editor": "^0.55.1",
+    "monaco-yaml": "^5.5.1",
     "svelte": "5.55.9",
     "tailwind-merge": "3.6.0",
     "tailwind-variants": "3.2.2",

--- a/web-ui/src/lib/api/client.ts
+++ b/web-ui/src/lib/api/client.ts
@@ -52,6 +52,11 @@ export function apiClient() {
     listArtifactsByService: (serviceId: string) =>
       json<unknown[]>(`/api/v1/artifacts/service/${serviceId}`),
 
+    listArtifactRefsByService: (serviceId: string) =>
+      json<unknown[]>(`/api/v1/artifacts/service/${serviceId}/refs`),
+
+    getArtifact: (id: string) => json<unknown>(`/api/v1/artifacts/${id}`),
+
     importArtifactFile: async (file: File, extra?: Record<string, string>) => {
       const fd = new FormData();
       fd.append('file', file);

--- a/web-ui/src/lib/artifacts/attach.ts
+++ b/web-ui/src/lib/artifacts/attach.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright The Reshapr Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { ReshaprArtifactKind } from './types.js';
+
+export type AttachArtifactClient = {
+	attachArtifactFile: (file: File) => Promise<unknown>;
+};
+
+/** Build a YAML file for POST `/api/v1/artifacts/attach`. */
+export function yamlToAttachFile(content: string, kind: ReshaprArtifactKind): File {
+	const filename = `${kind}.yaml`;
+	return new File([content], filename, { type: 'application/x-yaml' });
+}
+
+/** Save custom artifact YAML via attach (create or replace-by-type). Used in release 4. */
+export async function saveCustomArtifact(
+	client: AttachArtifactClient,
+	content: string,
+	kind: ReshaprArtifactKind
+): Promise<unknown> {
+	return client.attachArtifactFile(yamlToAttachFile(content, kind));
+}

--- a/web-ui/src/lib/artifacts/index.ts
+++ b/web-ui/src/lib/artifacts/index.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright The Reshapr Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export * from './types.js';
+export * from './kinds.js';
+export * from './templates.js';
+export * from './attach.js';
+export * from './parse.js';

--- a/web-ui/src/lib/artifacts/kinds.ts
+++ b/web-ui/src/lib/artifacts/kinds.ts
@@ -1,0 +1,114 @@
+/*
+ * Copyright The Reshapr Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { ArtifactType, ArtifactTypeFilter, ReshaprArtifactKind } from './types.js';
+
+export type KindDefinition = {
+	kind: ReshaprArtifactKind;
+	artifactType: ArtifactType;
+	label: string;
+	schemaPath: string;
+	isEditable: true;
+};
+
+/** Registry aligned with `ReshaprArtifactBuilder` kind → schema mappings. */
+export const EDITABLE_KINDS: KindDefinition[] = [
+	{
+		kind: 'Prompts',
+		artifactType: 'RESHAPR_PROMPTS',
+		label: 'Prompts',
+		schemaPath: '/schemas/Prompts-v1alpha1-schema.json',
+		isEditable: true
+	},
+	{
+		kind: 'CustomTools',
+		artifactType: 'RESHAPR_CUSTOM_TOOLS',
+		label: 'Custom tools',
+		schemaPath: '/schemas/CustomTools-v1alpha1-schema.json',
+		isEditable: true
+	},
+	{
+		kind: 'Resources',
+		artifactType: 'RESHAPR_RESOURCES',
+		label: 'Resources',
+		schemaPath: '/schemas/Resources-v1alpha1-schema.json',
+		isEditable: true
+	},
+	{
+		kind: 'ToolsOutputFilters',
+		artifactType: 'RESHAPR_TOOLS_OUTPUT_FILTERS',
+		label: 'Tools output filters',
+		schemaPath: '/schemas/ToolsOutputFilters-v1alpha1-schema.json',
+		isEditable: true
+	}
+];
+
+const KIND_BY_TYPE = new Map(
+	EDITABLE_KINDS.map((def) => [def.artifactType, def] as const)
+);
+
+export const ARTIFACT_TYPE_LABELS: Record<ArtifactType, string> = {
+	JSON_SCHEMA: 'JSON Schema',
+	OPEN_API_SPEC: 'OpenAPI spec',
+	GRAPHQL_SCHEMA: 'GraphQL schema',
+	PROTOBUF_SCHEMA: 'Protobuf schema',
+	PROTOBUF_DESCRIPTOR: 'Protobuf descriptor',
+	JSON_FRAGMENT: 'JSON fragment',
+	RESHAPR_PROMPTS: 'Prompts',
+	RESHAPR_CUSTOM_TOOLS: 'Custom tools',
+	RESHAPR_RESOURCES: 'Resources',
+	RESHAPR_TOOLS_OUTPUT_FILTERS: 'Tools output filters'
+};
+
+export const TYPE_FILTER_OPTIONS: { value: ArtifactTypeFilter; label: string }[] = [
+	{ value: 'all', label: 'All types' },
+	{ value: 'main', label: 'Main specification' },
+	...EDITABLE_KINDS.map((def) => ({
+		value: def.artifactType as ArtifactTypeFilter,
+		label: def.label
+	})),
+	{ value: 'OPEN_API_SPEC', label: 'OpenAPI spec' },
+	{ value: 'GRAPHQL_SCHEMA', label: 'GraphQL schema' },
+	{ value: 'PROTOBUF_SCHEMA', label: 'Protobuf schema' },
+	{ value: 'PROTOBUF_DESCRIPTOR', label: 'Protobuf descriptor' },
+	{ value: 'JSON_SCHEMA', label: 'JSON Schema' },
+	{ value: 'JSON_FRAGMENT', label: 'JSON fragment' }
+];
+
+export function getKindDefinition(kind: ReshaprArtifactKind): KindDefinition | undefined {
+	return EDITABLE_KINDS.find((def) => def.kind === kind);
+}
+
+export function getKindForArtifactType(type: ArtifactType): KindDefinition | undefined {
+	return KIND_BY_TYPE.get(type);
+}
+
+export function isEditableArtifactType(type: ArtifactType): boolean {
+	return KIND_BY_TYPE.has(type);
+}
+
+export function artifactTypeLabel(type: ArtifactType): string {
+	return ARTIFACT_TYPE_LABELS[type] ?? type;
+}
+
+export function matchesTypeFilter(
+	artifact: { type: ArtifactType; mainArtifact: boolean },
+	filter: ArtifactTypeFilter
+): boolean {
+	if (filter === 'all') return true;
+	if (filter === 'main') return artifact.mainArtifact;
+	return artifact.type === filter;
+}

--- a/web-ui/src/lib/artifacts/parse.ts
+++ b/web-ui/src/lib/artifacts/parse.ts
@@ -1,0 +1,99 @@
+/*
+ * Copyright The Reshapr Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type {
+	ArtifactDetail,
+	ArtifactRef,
+	ArtifactType,
+	ReshaprArtifactKind
+} from './types.js';
+
+const ARTIFACT_TYPES = new Set<string>([
+	'JSON_SCHEMA',
+	'OPEN_API_SPEC',
+	'GRAPHQL_SCHEMA',
+	'PROTOBUF_SCHEMA',
+	'PROTOBUF_DESCRIPTOR',
+	'JSON_FRAGMENT',
+	'RESHAPR_PROMPTS',
+	'RESHAPR_CUSTOM_TOOLS',
+	'RESHAPR_RESOURCES',
+	'RESHAPR_TOOLS_OUTPUT_FILTERS'
+]);
+
+function parseArtifactType(value: unknown): ArtifactType {
+	if (typeof value === 'string' && ARTIFACT_TYPES.has(value)) {
+		return value as ArtifactType;
+	}
+	return 'JSON_FRAGMENT';
+}
+
+export function parseArtifactRef(raw: unknown): ArtifactRef | null {
+	if (!raw || typeof raw !== 'object') return null;
+	const o = raw as Record<string, unknown>;
+	if (typeof o.id !== 'string') return null;
+	return {
+		id: o.id,
+		organizationId: typeof o.organizationId === 'string' ? o.organizationId : null,
+		name: typeof o.name === 'string' ? o.name : '—',
+		path: typeof o.path === 'string' ? o.path : null,
+		mainArtifact: o.mainArtifact === true,
+		sourceArtifact: typeof o.sourceArtifact === 'string' ? o.sourceArtifact : null,
+		type: parseArtifactType(o.type)
+	};
+}
+
+export function parseArtifactDetail(raw: unknown): ArtifactDetail | null {
+	const ref = parseArtifactRef(raw);
+	if (!ref) return null;
+	if (!raw || typeof raw !== 'object') return null;
+	const o = raw as Record<string, unknown>;
+	return {
+		...ref,
+		content: typeof o.content === 'string' ? o.content : null
+	};
+}
+
+export function parseArtifactRefList(raw: unknown): ArtifactRef[] {
+	if (!Array.isArray(raw)) return [];
+	return raw.map(parseArtifactRef).filter((row): row is ArtifactRef => row != null);
+}
+
+/** Read `kind:` from YAML or JSON artifact content (best-effort, client-side). */
+export function extractKindFromYaml(content: string): ReshaprArtifactKind | null {
+	const trimmed = content.trim();
+	if (!trimmed) return null;
+
+	if (trimmed.startsWith('{')) {
+		try {
+			const doc = JSON.parse(trimmed) as Record<string, unknown>;
+			return normalizeKind(doc.kind);
+		} catch {
+			return null;
+		}
+	}
+
+	const match = /^kind:\s*(\S+)/m.exec(content);
+	return match ? normalizeKind(match[1]) : null;
+}
+
+function normalizeKind(value: unknown): ReshaprArtifactKind | null {
+	if (value === 'Prompts' || value === 'CustomTools' || value === 'Resources') {
+		return value;
+	}
+	if (value === 'ToolsOutputFilters') return 'ToolsOutputFilters';
+	return null;
+}

--- a/web-ui/src/lib/artifacts/templates.ts
+++ b/web-ui/src/lib/artifacts/templates.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright The Reshapr Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { ReshaprArtifactKind, ServiceRef } from './types.js';
+
+const API_VERSION = 'reshapr.io/v1alpha1';
+
+function serviceBlock(service: ServiceRef): string {
+	return `service:
+  name: ${service.name}
+  version: ${service.version}`;
+}
+
+const PAYLOAD_BY_KIND: Record<ReshaprArtifactKind, string> = {
+	Prompts: 'prompts: {}',
+	CustomTools: 'customTools: {}',
+	Resources: 'resources: {}',
+	ToolsOutputFilters: 'filters: {}'
+};
+
+/** Minimal YAML skeleton for creating a new custom artifact (used in release 4). */
+export function buildTemplate(kind: ReshaprArtifactKind, service: ServiceRef): string {
+	return `apiVersion: ${API_VERSION}
+kind: ${kind}
+${serviceBlock(service)}
+${PAYLOAD_BY_KIND[kind]}
+`;
+}

--- a/web-ui/src/lib/artifacts/types.ts
+++ b/web-ui/src/lib/artifacts/types.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright The Reshapr Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** Mirrors control-plane `ArtifactType`. */
+export type ArtifactType =
+	| 'JSON_SCHEMA'
+	| 'OPEN_API_SPEC'
+	| 'GRAPHQL_SCHEMA'
+	| 'PROTOBUF_SCHEMA'
+	| 'PROTOBUF_DESCRIPTOR'
+	| 'JSON_FRAGMENT'
+	| 'RESHAPR_PROMPTS'
+	| 'RESHAPR_CUSTOM_TOOLS'
+	| 'RESHAPR_RESOURCES'
+	| 'RESHAPR_TOOLS_OUTPUT_FILTERS';
+
+export type ReshaprArtifactKind =
+	| 'Prompts'
+	| 'CustomTools'
+	| 'Resources'
+	| 'ToolsOutputFilters';
+
+export type EditorMode = 'create' | 'edit' | 'view';
+
+export type ArtifactRef = {
+	id: string;
+	organizationId: string | null;
+	name: string;
+	path: string | null;
+	mainArtifact: boolean;
+	sourceArtifact: string | null;
+	type: ArtifactType;
+};
+
+export type ArtifactDetail = ArtifactRef & {
+	content: string | null;
+};
+
+/** List filter on the Artifacts hub. */
+export type ArtifactTypeFilter = 'all' | 'main' | ArtifactType;
+
+export type ServiceRef = {
+	name: string;
+	version: string;
+};

--- a/web-ui/src/lib/components/ArtifactListTable.svelte
+++ b/web-ui/src/lib/components/ArtifactListTable.svelte
@@ -1,0 +1,159 @@
+<!--
+  ~ Copyright The Reshapr Authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<script lang="ts">
+	import {
+		artifactTypeLabel,
+		EDITABLE_KINDS,
+		isEditableArtifactType,
+		matchesTypeFilter,
+		TYPE_FILTER_OPTIONS,
+		type ArtifactRef,
+		type ArtifactTypeFilter,
+		type ReshaprArtifactKind
+	} from '$lib/artifacts/index.js';
+	import { Badge } from '$lib/components/ui/badge/index.js';
+	import { Button } from '$lib/components/ui/button/index.js';
+	import { Label } from '$lib/components/ui/label/index.js';
+	import * as Select from '$lib/components/ui/select/index.js';
+	import * as Table from '$lib/components/ui/table/index.js';
+
+	let {
+		serviceId,
+		artifacts = [],
+		loading = false
+	}: {
+		serviceId: string;
+		artifacts?: ArtifactRef[];
+		loading?: boolean;
+	} = $props();
+
+	let typeFilter = $state<ArtifactTypeFilter>('all');
+	let createKind = $state<ReshaprArtifactKind>('Prompts');
+
+	const filterLabel = $derived(
+		TYPE_FILTER_OPTIONS.find((opt) => opt.value === typeFilter)?.label ?? 'All types'
+	);
+
+	const createKindLabel = $derived(
+		EDITABLE_KINDS.find((def) => def.kind === createKind)?.label ?? createKind
+	);
+
+	const filtered = $derived(
+		artifacts.filter((artifact) => matchesTypeFilter(artifact, typeFilter))
+	);
+
+	function artifactHref(id: string): string {
+		return `/services/${serviceId}/artifacts/${id}`;
+	}
+
+	function createHref(): string {
+		return `/services/${serviceId}/artifacts/new?kind=${encodeURIComponent(createKind)}`;
+	}
+</script>
+
+<div class="mb-4 flex flex-wrap items-end justify-between gap-4">
+	<div class="space-y-2">
+		<Label for="artifact-type-filter">Filter by type</Label>
+		<Select.Root type="single" bind:value={typeFilter}>
+			<Select.Trigger id="artifact-type-filter" class="w-[min(100%,16rem)]">
+				{filterLabel}
+			</Select.Trigger>
+			<Select.Content>
+				{#each TYPE_FILTER_OPTIONS as opt (opt.value)}
+					<Select.Item value={opt.value}>{opt.label}</Select.Item>
+				{/each}
+			</Select.Content>
+		</Select.Root>
+	</div>
+
+	<div class="flex flex-wrap items-end gap-2">
+		<div class="space-y-2">
+			<Label for="artifact-create-kind">New custom artifact</Label>
+			<Select.Root type="single" bind:value={createKind}>
+				<Select.Trigger id="artifact-create-kind" class="w-[min(100%,14rem)]">
+					{createKindLabel}
+				</Select.Trigger>
+				<Select.Content>
+					{#each EDITABLE_KINDS as def (def.kind)}
+						<Select.Item value={def.kind}>{def.label}</Select.Item>
+					{/each}
+				</Select.Content>
+			</Select.Root>
+		</div>
+		<Button href={createHref()} class="mb-0">Create</Button>
+	</div>
+</div>
+
+<div class="rounded-lg border">
+	<Table.Root>
+		<Table.Header>
+			<Table.Row>
+				<Table.Head>Name</Table.Head>
+				<Table.Head>Type</Table.Head>
+				<Table.Head>Role</Table.Head>
+				<Table.Head>Source</Table.Head>
+				<Table.Head class="text-right">Actions</Table.Head>
+			</Table.Row>
+		</Table.Header>
+		<Table.Body>
+			{#if loading}
+				<Table.Row>
+					<Table.Cell colspan={5} class="text-muted-foreground">Loading…</Table.Cell>
+				</Table.Row>
+			{:else if filtered.length === 0}
+				<Table.Row>
+					<Table.Cell colspan={5} class="text-muted-foreground">
+						{artifacts.length === 0
+							? 'No artifacts for this service.'
+							: 'No artifacts match this filter.'}
+					</Table.Cell>
+				</Table.Row>
+			{:else}
+				{#each filtered as artifact (artifact.id)}
+					<Table.Row>
+						<Table.Cell>
+							<div class="font-medium">{artifact.name}</div>
+							<div class="text-muted-foreground font-mono text-xs">{artifact.id}</div>
+						</Table.Cell>
+						<Table.Cell>
+							<span class="text-sm">{artifactTypeLabel(artifact.type)}</span>
+						</Table.Cell>
+						<Table.Cell>
+							{#if artifact.mainArtifact}
+								<Badge variant="default">Main</Badge>
+							{:else}
+								<Badge variant="secondary">Attached</Badge>
+							{/if}
+							{#if !isEditableArtifactType(artifact.type)}
+								<Badge variant="outline" class="ml-1">Read-only</Badge>
+							{/if}
+						</Table.Cell>
+						<Table.Cell class="max-w-[12rem] truncate text-sm" title={artifact.sourceArtifact ?? undefined}>
+							{artifact.sourceArtifact ?? '—'}
+						</Table.Cell>
+						<Table.Cell class="text-right">
+							<Button variant="link" size="sm" href={artifactHref(artifact.id)}>View</Button>
+							{#if isEditableArtifactType(artifact.type)}
+								<Button variant="link" size="sm" href={artifactHref(artifact.id)}>Edit</Button>
+							{/if}
+						</Table.Cell>
+					</Table.Row>
+				{/each}
+			{/if}
+		</Table.Body>
+	</Table.Root>
+</div>

--- a/web-ui/src/lib/components/YamlMonacoEditor.svelte
+++ b/web-ui/src/lib/components/YamlMonacoEditor.svelte
@@ -1,0 +1,144 @@
+<!--
+  ~ Copyright The Reshapr Authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { ensureMonacoYaml } from '$lib/monaco/setup.js';
+	import ScrollableCode from '$lib/components/ScrollableCode.svelte';
+	import type * as Monaco from 'monaco-editor';
+
+	let {
+		value = '',
+		readOnly = false,
+		height = '24rem',
+		schemaUri = undefined,
+		onChange = undefined,
+		onValidationChange = undefined
+	}: {
+		value?: string;
+		readOnly?: boolean;
+		height?: string;
+		/** Reserved for release 3 JSON Schema completion. */
+		schemaUri?: string;
+		onChange?: (value: string) => void;
+		onValidationChange?: (markers: Monaco.editor.IMarker[]) => void;
+	} = $props();
+
+	let container = $state<HTMLDivElement | null>(null);
+	let editor = $state<Monaco.editor.IStandaloneCodeEditor | null>(null);
+	let model = $state<Monaco.editor.ITextModel | null>(null);
+	let loading = $state(true);
+	let loadError = $state<string | null>(null);
+
+	const heightStyle = $derived(typeof height === 'number' ? `${height}px` : height);
+
+	function emitValidation(monaco: typeof Monaco) {
+		if (!model || !onValidationChange) return;
+		onValidationChange(monaco.editor.getModelMarkers({ resource: model.uri }));
+	}
+
+	onMount(() => {
+		let disposed = false;
+		let markerDisposable: Monaco.IDisposable | null = null;
+		let contentDisposable: Monaco.IDisposable | null = null;
+
+		void (async () => {
+			if (!container) return;
+			try {
+				const monaco = await ensureMonacoYaml();
+				if (disposed || !container) return;
+
+				const uri = monaco.Uri.parse(
+					`inmemory://reshapr/${schemaUri ?? 'artifact'}/${crypto.randomUUID()}.yaml`
+				);
+				const textModel = monaco.editor.createModel(value, 'yaml', uri);
+				model = textModel;
+
+				const instance = monaco.editor.create(container, {
+					model: textModel,
+					language: 'yaml',
+					readOnly,
+					automaticLayout: true,
+					minimap: { enabled: false },
+					scrollBeyondLastLine: false,
+					wordWrap: 'on',
+					tabSize: 2,
+					fontSize: 13,
+					theme: 'vs'
+				});
+				editor = instance;
+
+				if (onChange) {
+					contentDisposable = textModel.onDidChangeContent(() => {
+						onChange(textModel.getValue());
+					});
+				}
+
+				if (onValidationChange) {
+					markerDisposable = monaco.editor.onDidChangeMarkers((uris) => {
+						if (uris.some((u) => u.toString() === textModel.uri.toString())) {
+							emitValidation(monaco);
+						}
+					});
+					emitValidation(monaco);
+				}
+			} catch (e) {
+				loadError = e instanceof Error ? e.message : String(e);
+			} finally {
+				if (!disposed) loading = false;
+			}
+		})();
+
+		return () => {
+			disposed = true;
+			markerDisposable?.dispose();
+			contentDisposable?.dispose();
+			editor?.dispose();
+			model?.dispose();
+			editor = null;
+			model = null;
+		};
+	});
+
+	$effect(() => {
+		if (!editor || !model) return;
+		const current = model.getValue();
+		if (value !== current) {
+			model.setValue(value);
+		}
+	});
+
+	$effect(() => {
+		if (!editor) return;
+		editor.updateOptions({ readOnly });
+	});
+</script>
+
+{#if loadError}
+	<ScrollableCode text={value || '—'} maxHeight={heightStyle} />
+	<p class="text-destructive mt-2 text-xs">Editor failed to load: {loadError}</p>
+{:else}
+	<div class="relative overflow-hidden rounded-lg border" style:height={heightStyle}>
+		<div bind:this={container} class="h-full w-full" role="presentation"></div>
+		{#if loading}
+			<div
+				class="bg-muted text-muted-foreground absolute inset-0 flex items-center justify-center font-mono text-xs"
+			>
+				Loading editor…
+			</div>
+		{/if}
+	</div>
+{/if}

--- a/web-ui/src/lib/monaco/setup.ts
+++ b/web-ui/src/lib/monaco/setup.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright The Reshapr Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import EditorWorker from 'monaco-editor/esm/vs/editor/editor.worker?worker';
+import YamlWorker from './yaml.worker.js?worker';
+
+import type * as Monaco from 'monaco-editor';
+
+let monacoPromise: Promise<typeof Monaco> | null = null;
+
+function configureWorkers(): void {
+	if (globalThis.MonacoEnvironment) return;
+
+	globalThis.MonacoEnvironment = {
+		getWorker(_moduleId: string, label: string) {
+			switch (label) {
+				case 'editorWorkerService':
+					return new EditorWorker();
+				case 'yaml':
+					return new YamlWorker();
+				default:
+					throw new Error(`Unknown Monaco worker label: ${label}`);
+			}
+		}
+	};
+}
+
+/** Client-only Monaco + YAML language registration (schemas wired in release 3). */
+export async function ensureMonacoYaml(): Promise<typeof Monaco> {
+	if (monacoPromise) return monacoPromise;
+
+	monacoPromise = (async () => {
+		configureWorkers();
+		await import('monaco-editor/min/vs/editor/editor.main.css');
+		const monaco = await import('monaco-editor');
+		const { configureMonacoYaml } = await import('monaco-yaml');
+
+		configureMonacoYaml(monaco, {
+			enableSchemaRequest: true,
+			schemas: []
+		});
+
+		return monaco;
+	})();
+
+	return monacoPromise;
+}

--- a/web-ui/src/lib/monaco/yaml.worker.ts
+++ b/web-ui/src/lib/monaco/yaml.worker.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright The Reshapr Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** Vite worker entry — see monaco-yaml FAQ for Vite. */
+import 'monaco-yaml/yaml.worker.js';

--- a/web-ui/src/routes/(app)/services/[id]/artifacts/+page.svelte
+++ b/web-ui/src/routes/(app)/services/[id]/artifacts/+page.svelte
@@ -17,14 +17,15 @@
 <script lang="ts">
 	import { getContext } from 'svelte';
 	import { apiClient, ApiError } from '$lib/api/client.js';
+	import { parseArtifactRefList, type ArtifactRef } from '$lib/artifacts/index.js';
 	import ApiErrorAlert from '$lib/components/ApiErrorAlert.svelte';
-	import JsonBlock from '$lib/components/JsonBlock.svelte';
+	import ArtifactListTable from '$lib/components/ArtifactListTable.svelte';
 	import { SERVICE_CONTEXT_KEY, type ServiceContextValue } from '$lib/serviceContext.js';
 	import { Button } from '$lib/components/ui/button/index.js';
 
 	const ctx = getContext<ServiceContextValue>(SERVICE_CONTEXT_KEY);
 
-	let data = $state<unknown[]>([]);
+	let artifacts = $state<ArtifactRef[]>([]);
 	let error = $state<string | null>(null);
 	let loading = $state(true);
 
@@ -33,11 +34,11 @@
 		loading = true;
 		error = null;
 		try {
-			const list = await apiClient().listArtifactsByService(ctx.id);
-			data = Array.isArray(list) ? list : [];
+			const list = await apiClient().listArtifactRefsByService(ctx.id);
+			artifacts = parseArtifactRefList(list);
 		} catch (e) {
 			error = e instanceof ApiError ? e.message : String(e);
-			data = [];
+			artifacts = [];
 		} finally {
 			loading = false;
 		}
@@ -54,7 +55,7 @@
 </div>
 
 <p class="text-muted-foreground mb-4 text-sm">
-	Import and attach flows are available under
+	List, filter and manage custom artifacts here. Main specification import remains under
 	<a href="/artifacts" class="text-primary hover:underline">Experimental → Artifacts</a>.
 </p>
 
@@ -62,8 +63,4 @@
 	<ApiErrorAlert message={error} />
 {/if}
 
-<JsonBlock value={data} {loading} />
-
-{#if !loading && !error && data.length === 0}
-	<p class="text-muted-foreground mt-4 text-sm">No artifacts for this service.</p>
-{/if}
+<ArtifactListTable serviceId={ctx.id} {artifacts} {loading} />

--- a/web-ui/src/routes/(app)/services/[id]/artifacts/[artifactId]/+page.svelte
+++ b/web-ui/src/routes/(app)/services/[id]/artifacts/[artifactId]/+page.svelte
@@ -20,13 +20,16 @@
 	import { apiClient, ApiError } from '$lib/api/client.js';
 	import {
 		artifactTypeLabel,
+		buildTemplate,
 		getKindDefinition,
+		getKindForArtifactType,
 		isEditableArtifactType,
 		parseArtifactDetail,
 		type ArtifactType,
 		type ReshaprArtifactKind
 	} from '$lib/artifacts/index.js';
 	import ApiErrorAlert from '$lib/components/ApiErrorAlert.svelte';
+	import YamlMonacoEditor from '$lib/components/YamlMonacoEditor.svelte';
 	import { SERVICE_CONTEXT_KEY, type ServiceContextValue } from '$lib/serviceContext.js';
 	import { Badge } from '$lib/components/ui/badge/index.js';
 	import { Button } from '$lib/components/ui/button/index.js';
@@ -45,8 +48,26 @@
 	let loading = $state(false);
 	let artifactName = $state<string | null>(null);
 	let artifactType = $state<ArtifactType | null>(null);
+	let artifactContent = $state('');
 
 	const listHref = $derived(`/services/${ctx.id}/artifacts`);
+
+	const schemaUri = $derived(
+		isCreate
+			? createKindDef?.schemaPath
+			: artifactType
+				? getKindForArtifactType(artifactType)?.schemaPath
+				: undefined
+	);
+
+	const editorValue = $derived(
+		isCreate
+			? buildTemplate(createKind, {
+					name: ctx.service?.name ?? '—',
+					version: ctx.service?.version ?? '—'
+				})
+			: artifactContent
+	);
 
 	async function loadArtifact() {
 		if (isCreate || !artifactId) return;
@@ -54,6 +75,7 @@
 		error = null;
 		artifactName = null;
 		artifactType = null;
+		artifactContent = '';
 		try {
 			const raw = await apiClient().getArtifact(artifactId);
 			const detail = parseArtifactDetail(raw);
@@ -63,6 +85,7 @@
 			}
 			artifactName = detail.name;
 			artifactType = detail.type;
+			artifactContent = detail.content ?? '';
 		} catch (e) {
 			error = e instanceof ApiError ? e.message : String(e);
 		} finally {
@@ -90,7 +113,7 @@
 	<ApiErrorAlert message={error} />
 {/if}
 
-<Card.Root>
+<Card.Root class="mb-4">
 	<Card.Header>
 		<Card.Title>
 			{#if isCreate}
@@ -103,25 +126,23 @@
 		</Card.Title>
 		<Card.Description>
 			{#if isCreate}
-				YAML editor and save flow ship in release 2–4 of this feature branch.
+				Template preview (read-only). Save flow ships in release 4.
 			{:else if artifactType}
 				Type: {artifactTypeLabel(artifactType)}
 				{#if !isEditableArtifactType(artifactType)}
 					<Badge variant="outline" class="ml-2">Read-only</Badge>
+				{:else}
+					<Badge variant="secondary" class="ml-2">Read-only preview</Badge>
 				{/if}
-			{:else}
-				Placeholder until the Monaco editor lands (release 2+).
+			{:else if !loading}
+				YAML source
 			{/if}
 		</Card.Description>
 	</Card.Header>
-	<Card.Content class="text-muted-foreground text-sm">
-		{#if isCreate}
-			<p>
-				Kind <code class="text-xs">{createKind}</code> selected. The unified editor will open here in
-				<code class="text-xs">release4</code>.
-			</p>
-		{:else}
-			<p>Artifact <code class="text-xs">{artifactId}</code> — view and edit UI coming in release 2+.</p>
-		{/if}
-	</Card.Content>
 </Card.Root>
+
+{#if isCreate || (!loading && !error)}
+	<YamlMonacoEditor value={editorValue} readOnly={true} {schemaUri} height="min(70vh, 32rem)" />
+{:else if loading}
+	<p class="text-muted-foreground text-sm">Loading artifact content…</p>
+{/if}

--- a/web-ui/src/routes/(app)/services/[id]/artifacts/[artifactId]/+page.svelte
+++ b/web-ui/src/routes/(app)/services/[id]/artifacts/[artifactId]/+page.svelte
@@ -1,0 +1,127 @@
+<!--
+  ~ Copyright The Reshapr Authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<script lang="ts">
+	import { getContext } from 'svelte';
+	import { page } from '$app/state';
+	import { apiClient, ApiError } from '$lib/api/client.js';
+	import {
+		artifactTypeLabel,
+		getKindDefinition,
+		isEditableArtifactType,
+		parseArtifactDetail,
+		type ArtifactType,
+		type ReshaprArtifactKind
+	} from '$lib/artifacts/index.js';
+	import ApiErrorAlert from '$lib/components/ApiErrorAlert.svelte';
+	import { SERVICE_CONTEXT_KEY, type ServiceContextValue } from '$lib/serviceContext.js';
+	import { Badge } from '$lib/components/ui/badge/index.js';
+	import { Button } from '$lib/components/ui/button/index.js';
+	import * as Card from '$lib/components/ui/card/index.js';
+
+	const ctx = getContext<ServiceContextValue>(SERVICE_CONTEXT_KEY);
+
+	const artifactId = $derived(page.params.artifactId ?? '');
+	const isCreate = $derived(artifactId === 'new');
+	const createKind = $derived(
+		(page.url.searchParams.get('kind') as ReshaprArtifactKind | null) ?? 'Prompts'
+	);
+	const createKindDef = $derived(getKindDefinition(createKind));
+
+	let error = $state<string | null>(null);
+	let loading = $state(false);
+	let artifactName = $state<string | null>(null);
+	let artifactType = $state<ArtifactType | null>(null);
+
+	const listHref = $derived(`/services/${ctx.id}/artifacts`);
+
+	async function loadArtifact() {
+		if (isCreate || !artifactId) return;
+		loading = true;
+		error = null;
+		artifactName = null;
+		artifactType = null;
+		try {
+			const raw = await apiClient().getArtifact(artifactId);
+			const detail = parseArtifactDetail(raw);
+			if (!detail) {
+				error = 'Artifact not found or invalid response.';
+				return;
+			}
+			artifactName = detail.name;
+			artifactType = detail.type;
+		} catch (e) {
+			error = e instanceof ApiError ? e.message : String(e);
+		} finally {
+			loading = false;
+		}
+	}
+
+	$effect(() => {
+		if (ctx.id && !ctx.loading && !isCreate && artifactId) void loadArtifact();
+	});
+</script>
+
+<div class="mb-4 flex flex-wrap items-center justify-between gap-4">
+	<h3 class="text-lg font-semibold">
+		{#if isCreate}
+			New custom artifact
+		{:else}
+			Artifact detail
+		{/if}
+	</h3>
+	<Button variant="outline" size="sm" href={listHref}>Back to list</Button>
+</div>
+
+{#if error}
+	<ApiErrorAlert message={error} />
+{/if}
+
+<Card.Root>
+	<Card.Header>
+		<Card.Title>
+			{#if isCreate}
+				{createKindDef?.label ?? createKind}
+			{:else if loading}
+				Loading…
+			{:else}
+				{artifactName ?? artifactId}
+			{/if}
+		</Card.Title>
+		<Card.Description>
+			{#if isCreate}
+				YAML editor and save flow ship in release 2–4 of this feature branch.
+			{:else if artifactType}
+				Type: {artifactTypeLabel(artifactType)}
+				{#if !isEditableArtifactType(artifactType)}
+					<Badge variant="outline" class="ml-2">Read-only</Badge>
+				{/if}
+			{:else}
+				Placeholder until the Monaco editor lands (release 2+).
+			{/if}
+		</Card.Description>
+	</Card.Header>
+	<Card.Content class="text-muted-foreground text-sm">
+		{#if isCreate}
+			<p>
+				Kind <code class="text-xs">{createKind}</code> selected. The unified editor will open here in
+				<code class="text-xs">release4</code>.
+			</p>
+		{:else}
+			<p>Artifact <code class="text-xs">{artifactId}</code> — view and edit UI coming in release 2+.</p>
+		{/if}
+	</Card.Content>
+</Card.Root>

--- a/web-ui/vite.config.ts
+++ b/web-ui/vite.config.ts
@@ -3,9 +3,9 @@ import tailwindcss from '@tailwindcss/vite';
 import { defineConfig } from 'vite';
 
 export default defineConfig({
-  plugins: [
-    tailwindcss(),
-    sveltekit()
-  ]
+  plugins: [tailwindcss(), sveltekit()],
+  worker: {
+    format: 'es'
+  }
 });
 


### PR DESCRIPTION
## Summary

This PR delivers **release 1 and 2** of the Artifacts Monaco editor feature: a structured **Artifacts hub** per service and a **client-only YAML preview** via Monaco (Issue #208).

### Lot 1 — Artifacts hub

- Replace the raw JSON dump on `/services/{id}/artifacts` with a navigable table
- Use lightweight `GET /artifacts/service/{id}/refs` instead of loading full artifact content in the list
- Add `lib/artifacts/` (types, kinds registry, templates, attach helpers, YAML parsing)
- Add `ArtifactListTable` with type filter, read-only badges, and create entry points (kind selector → `/artifacts/new?kind=…`)
- Extend API client with `listArtifactRefsByService` and `getArtifact`

### Lot 2 — YamlMonacoEditor

- Add `monaco-editor` + `monaco-yaml` with Vite worker setup
- Add reusable `YamlMonacoEditor.svelte` (client-only dynamic import, fallback to `ScrollableCode` on failure)
- Show read-only YAML on artifact detail (`/artifacts/{id}`) and create template preview (`/artifacts/new?kind=…`)

### Out of scope (follow-up PRs)

| Release | Content |
|---------|---------|
| `release3` | JSON Schema completion |
| `release4` | Editable create/save via `CustomArtifactEditor` |
| `release5` | MCP tab deep links (optional) |

### Design notes

- No SSR change — app stays SPA (`ssr = false`); Monaco is browser-only
- Single Artifacts hub for list / filter / create / edit — no Monaco duplicated on MCP pages
- Main spec artifacts remain read-only; only the 4 custom kinds are targeted for future editing

## Test plan

- [ ] Open `/services/{serviceId}/artifacts` — table with filter, badges (Main / Attached / Read-only), Create button
- [ ] Filter by type (All, Main specification, Prompts, Custom tools, etc.)
- [ ] Click **View** on an artifact → Monaco read-only YAML loads
- [ ] **Create** with kind `Prompts` → template YAML shown in read-only Monaco
- [ ] Main spec artifact → View works, read-only badge, no misleading Edit affordance
- [ ] Experimental `/artifacts` page unchanged (import spec flows)
- [ ] `npm run check` and `npm run build` pass in `web-ui`