### PR TITLE
Fix local Keycloak redirect URI for proxy callbacks

### DIFF
--- a/dev/3rdparty-realm.json
+++ b/dev/3rdparty-realm.json
@@ -333,7 +333,7 @@
       "alwaysDisplayInConsole": false,
       "clientAuthenticatorType": "client-secret",
       "redirectUris": [
-        "http://localhost:5555/*"
+        "http://localhost:7777/*"
       ],
       "webOrigins": [
         "+"

--- a/dev/3rdparty-realm.json
+++ b/dev/3rdparty-realm.json
@@ -333,6 +333,7 @@
       "alwaysDisplayInConsole": false,
       "clientAuthenticatorType": "client-secret",
       "redirectUris": [
+        "http://localhost:5555/*",
         "http://localhost:7777/*"
       ],
       "webOrigins": [


### PR DESCRIPTION
## Summary
- update the imported local Keycloak realm so the `reshapr-ctrl` client also allows proxy redirect callbacks
- preserve the existing `http://localhost:5555/*` redirect URI for external IDP auth testing
- add `http://localhost:7777/*` for local proxy/gateway OAuth elicitation callbacks

## Why
In the local all-in-one setup, the proxy/gateway is exposed on port `7777`, and proxy OAuth elicitation callbacks are built from `reshapr.gateway.fqdns`, which defaults to `localhost:7777`.

The same imported realm is also used for testing authentication through an external IDP, which still needs `http://localhost:5555/*`.

Closes #231.