### PR TITLE
Enable dynamic Keycloak backchannel URLs for local Docker OIDC

### DIFF
--- a/dev/start-keycloak-docker.sh
+++ b/dev/start-keycloak-docker.sh
@@ -22,7 +22,7 @@ docker run -d --rm --name "${CONTAINER_NAME}" \
   -e KC_HOSTNAME_STRICT=false \
   -e KC_HTTP_ENABLED=true \
   "${KEYCLOAK_IMAGE}" \
-  start-dev --hostname "http://localhost:${HOST_PORT}" --import-realm
+  start-dev --hostname "http://localhost:${HOST_PORT}" --import-realm --hostname-backchannel-dynamic true
 
 echo "Waiting for Keycloak to be ready ..."
 READY=0


### PR DESCRIPTION
## Summary
- enable dynamic Keycloak backchannel URL resolution in the local Keycloak dev startup script
- keep the browser-facing Keycloak hostname fixed while allowing backend OIDC calls to resolve the local Docker network address

## Why
The local Keycloak script pins the frontend hostname to `http://localhost:${HOST_PORT}`. In Docker-based OIDC flows, backend calls may reach Keycloak through a different local address such as `host.docker.internal`.

Keycloak documents `--hostname-backchannel-dynamic true` for this split frontend/backchannel setup:

https://www.keycloak.org/server/hostname#_utilizing_an_internal_url_for_communication_among_clients

Closes #233.