### PR TITLE
feat: implement server/discover MCP endpoint

### DIFF
--- a/proxy/src/main/java/io/reshapr/proxy/mcp/McpController.java
+++ b/proxy/src/main/java/io/reshapr/proxy/mcp/McpController.java
@@ -247,6 +247,9 @@ public class McpController {
    private McpHandlerResult handleMcpRequest(ExpositionEntry exposition, McpSchema.JSONRPCRequest request, HttpHeaders headers) {
       McpHandlerResult result = null;
       switch (request.method()) {
+         case McpSchema.METHOD_SERVER_DISCOVER ->
+            result = handleServerDiscoverRequest(request, exposition);
+
          case McpSchema.METHOD_INITIALIZE ->
             result = handleInitializeRequest(request, exposition);
 
@@ -292,6 +295,27 @@ public class McpController {
       public boolean isJSONRPCResponse() {
          return message instanceof McpSchema.JSONRPCResponse;
       }
+   }
+
+   /** Handle the MCP server/discover request. */
+   private McpHandlerResult handleServerDiscoverRequest(McpSchema.JSONRPCRequest request, ExpositionEntry exposition) {
+      ServiceEntry service = exposition.service();
+      McpSchema.ServerCapabilities serverCapabilities = new McpSchema.ServerCapabilities(null, null,
+            new McpSchema.ServerCapabilities.PromptCapabilities(false),
+            new McpSchema.ServerCapabilities.ResourceCapabilities(false, false),
+            new McpSchema.ServerCapabilities.ToolCapabilities(false));
+
+      Map<String, Object> meta = Map.of(
+            "io.modelcontextprotocol/serverInfo", new McpSchema.Implementation(service.name() + " MCP server", service.version())
+      );
+
+      McpSchema.DiscoverResult discoverResult = new McpSchema.DiscoverResult(
+            McpSchema.SUPPORTED_PROTOCOL_VERSIONS,
+            serverCapabilities,
+            meta,
+            null);
+
+      return toMcpHandlerResult(request, discoverResult);
    }
 
    /** Handle the MCP initialize request. */

--- a/proxy/src/main/java/io/reshapr/proxy/mcp/McpSchema.java
+++ b/proxy/src/main/java/io/reshapr/proxy/mcp/McpSchema.java
@@ -58,6 +58,7 @@ public class McpSchema {
    public static final String METHOD_INITIALIZE = "initialize";
    public static final String METHOD_NOTIFICATION_INITIALIZED = "notifications/initialized";
    public static final String METHOD_PING = "ping";
+   public static final String METHOD_SERVER_DISCOVER = "server/discover";
 
    // Tool Methods
    public static final String METHOD_TOOLS_LIST = "tools/list";
@@ -289,6 +290,22 @@ public class McpSchema {
         @JsonProperty("capabilities") ServerCapabilities capabilities,
         @JsonProperty("serverInfo") Implementation serverInfo,
         @JsonProperty("instructions") String instructions) {
+   }
+
+   @JsonInclude(JsonInclude.Include.NON_ABSENT)
+   @JsonIgnoreProperties(ignoreUnknown = true)
+   public record DiscoverResult(
+         @JsonProperty("resultType") String resultType,
+         @JsonProperty("supportedVersions") List<String> supportedVersions,
+         @JsonProperty("capabilities") ServerCapabilities capabilities,
+         @JsonProperty("_meta") Map<String, Object> meta,
+         @JsonProperty("instructions") String instructions,
+         @JsonProperty("ttlMs") Long ttlMs,
+         @JsonProperty("cacheScope") String cacheScope) implements Meta {
+
+      public DiscoverResult(List<String> supportedVersions, ServerCapabilities capabilities, Map<String, Object> meta, String instructions) {
+         this("complete", supportedVersions, capabilities, meta, instructions, null, null);
+      }
    }
 
    @JsonInclude(JsonInclude.Include.NON_ABSENT)


### PR DESCRIPTION
### Description
This PR implements the mandatory `server/discover` endpoint for the Model Context Protocol (MCP) server. This endpoint is required for upfront protocol negotiation and capability discovery by modern MCP clients.

### Testing
* Verified local compilation successfully.
* Temporary programmatic tests were written and executed.

Test Execution Logs

```text
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running io.reshapr.proxy.mcp.McpControllerTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.200 s -- in io.reshapr.proxy.mcp.McpControllerTest
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
```

Fixes #287 