### PR TITLE
feat: add response compaction filter for sparse JSON payloads (#293)

### DIFF
--- a/control-plane/src/main/resources/schemas/ToolsOutputFilters-v1alpha1-schema.json
+++ b/control-plane/src/main/resources/schemas/ToolsOutputFilters-v1alpha1-schema.json
@@ -75,6 +75,9 @@
           "required": ["jsonPatches"]
         },
         {
+          "required": ["compact"]
+        },
+        {
           "required": ["convertToToon"]
         }
       ],
@@ -95,6 +98,10 @@
             "$ref": "#/definitions/patchOperation"
           },
           "minItems": 1
+        },
+        "compact": {
+          "type": ["boolean", "object"],
+          "title": "Whether to compact the output by recursively removing sparse values (null, empty strings, empty arrays, empty objects)."
         },
         "convertToToon": {
           "type": "boolean",

--- a/proxy/src/main/java/io/reshapr/proxy/mcp/filters/ToolsOutputFiltersApplier.java
+++ b/proxy/src/main/java/io/reshapr/proxy/mcp/filters/ToolsOutputFiltersApplier.java
@@ -33,6 +33,7 @@ import org.jboss.logging.Logger;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -95,6 +96,12 @@ public class ToolsOutputFiltersApplier {
          JsonNode patchesNode = filterNode.get("jsonPatches");
          if (patchesNode != null && patchesNode.isArray()) {
             responseNode = JsonPatch.apply(patchesNode, responseNode);
+         }
+
+         // Then apply compact if present.
+         JsonNode compactNode = filterNode.get("compact");
+         if (isCompactEnabled(compactNode)) {
+            responseNode = applyCompaction(responseNode);
          }
 
          String result = JSON_MAPPER.writeValueAsString(responseNode);
@@ -291,5 +298,84 @@ public class ToolsOutputFiltersApplier {
             }
          }
       }
+   }
+
+   /**
+    * Checks whether the compact filter option is enabled for a tool.
+    */
+   private boolean isCompactEnabled(@Nullable JsonNode compactNode) {
+      if (compactNode == null) {
+         return false;
+      }
+      if (compactNode.isBoolean()) {
+         return compactNode.asBoolean();
+      }
+      return compactNode.isObject();
+   }
+
+   /**
+    * Compacts a JSON node by recursively removing sparse values (null, empty strings, empty arrays, empty objects).
+    * @param responseNode the root JSON node to compact
+    * @return the compacted JSON node
+    */
+   private JsonNode applyCompaction(JsonNode responseNode) {
+      return pruneNode(responseNode);
+   }
+
+   /**
+    * Recursively prunes sparse values (null, empty strings, empty arrays, empty objects) from a JSON node.
+    * @param node the current JSON node
+    * @return the pruned JSON node
+    */
+   private JsonNode pruneNode(JsonNode node) {
+      if (node.isObject()) {
+         ObjectNode objectNode = (ObjectNode) node;
+         Iterator<Map.Entry<String, JsonNode>> fields = objectNode.fields();
+         while (fields.hasNext()) {
+            Map.Entry<String, JsonNode> entry = fields.next();
+            JsonNode child = entry.getValue();
+
+            if (child.isContainerNode()) {
+               pruneNode(child);
+            }
+
+            if (isSparseValue(child)) {
+               fields.remove();
+            }
+         }
+      } else if (node.isArray()) {
+         ArrayNode arrayNode = (ArrayNode) node;
+         Iterator<JsonNode> elements = arrayNode.elements();
+         while (elements.hasNext()) {
+            JsonNode element = elements.next();
+            if (element.isContainerNode()) {
+               pruneNode(element);
+            }
+
+            if (isSparseValue(element)) {
+               elements.remove();
+            }
+         }
+      }
+      return node;
+   }
+
+   /**
+    * Checks if a JSON node represents a sparse value (null, empty string, empty array, or empty object).
+    */
+   private boolean isSparseValue(JsonNode node) {
+      if (node.isNull()) {
+         return true;
+      }
+      if (node.isTextual() && node.asText().isEmpty()) {
+         return true;
+      }
+      if (node.isArray() && node.isEmpty()) {
+         return true;
+      }
+      if (node.isObject() && node.isEmpty()) {
+         return true;
+      }
+      return false;
    }
 }

--- a/proxy/src/test/java/io/reshapr/proxy/mcp/filters/ToolsOutputFiltersApplierTest.java
+++ b/proxy/src/test/java/io/reshapr/proxy/mcp/filters/ToolsOutputFiltersApplierTest.java
@@ -363,4 +363,309 @@ class ToolsOutputFiltersApplierTest {
       assertTrue(filteredAccount.contains("FR76"));
       assertFalse(filteredAccount.contains("balance"));
    }
+
+   @Test
+   void testCompactRemovesNullFields() throws Exception {
+      String artifactContent = """
+            apiVersion: reshapr.io/v1alpha1
+            kind: ToolsOutputFilters
+            service:
+              name: Test API
+              version: '1.0.0'
+            filters:
+              compactTool:
+                compact: true
+            """;
+      ServiceEntry service = new ServiceEntry("svc-1", "org-1", "Test API", "1.0.0", "REST", null);
+      ArtifactEntry artifact = new ArtifactEntry("art-1", "filters.yaml", null,
+            ArtifactEntryType.RESHAPR_TOOLS_OUTPUT_FILTERS, false, artifactContent);
+      WorkCache cache = new WorkCache(100);
+      ToolsOutputFiltersApplier applier = new ToolsOutputFiltersApplier(service, List.of(artifact), cache);
+
+      String response = "{\"name\":\"Alice\",\"middleName\":null,\"age\":30}";
+      String filtered = applier.applyFilter("compactTool", response);
+
+      JsonNode result = MAPPER.readTree(filtered);
+      assertTrue(result.has("name"));
+      assertTrue(result.has("age"));
+      assertFalse(result.has("middleName"));
+   }
+
+   @Test
+   void testCompactRemovesEmptyStrings() throws Exception {
+      String artifactContent = """
+            apiVersion: reshapr.io/v1alpha1
+            kind: ToolsOutputFilters
+            service:
+              name: Test API
+              version: '1.0.0'
+            filters:
+              compactTool:
+                compact: true
+            """;
+      ServiceEntry service = new ServiceEntry("svc-1", "org-1", "Test API", "1.0.0", "REST", null);
+      ArtifactEntry artifact = new ArtifactEntry("art-1", "filters.yaml", null,
+            ArtifactEntryType.RESHAPR_TOOLS_OUTPUT_FILTERS, false, artifactContent);
+      WorkCache cache = new WorkCache(100);
+      ToolsOutputFiltersApplier applier = new ToolsOutputFiltersApplier(service, List.of(artifact), cache);
+
+      String response = "{\"name\":\"Bob\",\"bio\":\"\",\"status\":\"active\"}";
+      String filtered = applier.applyFilter("compactTool", response);
+
+      JsonNode result = MAPPER.readTree(filtered);
+      assertTrue(result.has("name"));
+      assertTrue(result.has("status"));
+      assertFalse(result.has("bio"));
+   }
+
+   @Test
+   void testCompactRemovesEmptyArrays() throws Exception {
+      String artifactContent = """
+            apiVersion: reshapr.io/v1alpha1
+            kind: ToolsOutputFilters
+            service:
+              name: Test API
+              version: '1.0.0'
+            filters:
+              compactTool:
+                compact: true
+            """;
+      ServiceEntry service = new ServiceEntry("svc-1", "org-1", "Test API", "1.0.0", "REST", null);
+      ArtifactEntry artifact = new ArtifactEntry("art-1", "filters.yaml", null,
+            ArtifactEntryType.RESHAPR_TOOLS_OUTPUT_FILTERS, false, artifactContent);
+      WorkCache cache = new WorkCache(100);
+      ToolsOutputFiltersApplier applier = new ToolsOutputFiltersApplier(service, List.of(artifact), cache);
+
+      String response = "{\"name\":\"Alice\",\"roles\":[\"admin\"],\"tags\":[]}";
+      String filtered = applier.applyFilter("compactTool", response);
+
+      JsonNode result = MAPPER.readTree(filtered);
+      assertTrue(result.has("name"));
+      assertTrue(result.has("roles"));
+      assertFalse(result.has("tags"));
+   }
+
+   @Test
+   void testCompactRemovesEmptyObjects() throws Exception {
+      String artifactContent = """
+            apiVersion: reshapr.io/v1alpha1
+            kind: ToolsOutputFilters
+            service:
+              name: Test API
+              version: '1.0.0'
+            filters:
+              compactTool:
+                compact: true
+            """;
+      ServiceEntry service = new ServiceEntry("svc-1", "org-1", "Test API", "1.0.0", "REST", null);
+      ArtifactEntry artifact = new ArtifactEntry("art-1", "filters.yaml", null,
+            ArtifactEntryType.RESHAPR_TOOLS_OUTPUT_FILTERS, false, artifactContent);
+      WorkCache cache = new WorkCache(100);
+      ToolsOutputFiltersApplier applier = new ToolsOutputFiltersApplier(service, List.of(artifact), cache);
+
+      String response = "{\"name\":\"Bob\",\"address\":{}}";
+      String filtered = applier.applyFilter("compactTool", response);
+
+      JsonNode result = MAPPER.readTree(filtered);
+      assertTrue(result.has("name"));
+      assertFalse(result.has("address"));
+   }
+
+   @Test
+   void testCompactNestedObjectCompaction() throws Exception {
+      String artifactContent = """
+            apiVersion: reshapr.io/v1alpha1
+            kind: ToolsOutputFilters
+            service:
+              name: Test API
+              version: '1.0.0'
+            filters:
+              compactTool:
+                compact: true
+            """;
+      ServiceEntry service = new ServiceEntry("svc-1", "org-1", "Test API", "1.0.0", "REST", null);
+      ArtifactEntry artifact = new ArtifactEntry("art-1", "filters.yaml", null,
+            ArtifactEntryType.RESHAPR_TOOLS_OUTPUT_FILTERS, false, artifactContent);
+      WorkCache cache = new WorkCache(100);
+      ToolsOutputFiltersApplier applier = new ToolsOutputFiltersApplier(service, List.of(artifact), cache);
+
+      String response = "{\"user\":{\"name\":\"Alice\",\"middleName\":null,\"bio\":\"\"},\"emptyUser\":{\"note\":\"\"}}";
+      String filtered = applier.applyFilter("compactTool", response);
+
+      JsonNode result = MAPPER.readTree(filtered);
+      assertTrue(result.has("user"));
+      assertEquals("Alice", result.get("user").get("name").asText());
+      assertFalse(result.get("user").has("middleName"));
+      assertFalse(result.get("user").has("bio"));
+      // emptyUser became empty after bio was pruned, so emptyUser itself is pruned
+      assertFalse(result.has("emptyUser"));
+   }
+
+   @Test
+   void testCompactArrayCompaction() throws Exception {
+      String artifactContent = """
+            apiVersion: reshapr.io/v1alpha1
+            kind: ToolsOutputFilters
+            service:
+              name: Test API
+              version: '1.0.0'
+            filters:
+              compactTool:
+                compact: true
+            """;
+      ServiceEntry service = new ServiceEntry("svc-1", "org-1", "Test API", "1.0.0", "REST", null);
+      ArtifactEntry artifact = new ArtifactEntry("art-1", "filters.yaml", null,
+            ArtifactEntryType.RESHAPR_TOOLS_OUTPUT_FILTERS, false, artifactContent);
+      WorkCache cache = new WorkCache(100);
+      ToolsOutputFiltersApplier applier = new ToolsOutputFiltersApplier(service, List.of(artifact), cache);
+
+      String response = "[\"active\",null,\"\",[],{}]";
+      String filtered = applier.applyFilter("compactTool", response);
+
+      JsonNode result = MAPPER.readTree(filtered);
+      assertTrue(result.isArray());
+      assertEquals(1, result.size());
+      assertEquals("active", result.get(0).asText());
+   }
+
+   @Test
+   void testCompactNestedArraysOfObjects() throws Exception {
+      String artifactContent = """
+            apiVersion: reshapr.io/v1alpha1
+            kind: ToolsOutputFilters
+            service:
+              name: Test API
+              version: '1.0.0'
+            filters:
+              compactTool:
+                compact: true
+            """;
+      ServiceEntry service = new ServiceEntry("svc-1", "org-1", "Test API", "1.0.0", "REST", null);
+      ArtifactEntry artifact = new ArtifactEntry("art-1", "filters.yaml", null,
+            ArtifactEntryType.RESHAPR_TOOLS_OUTPUT_FILTERS, false, artifactContent);
+      WorkCache cache = new WorkCache(100);
+      ToolsOutputFiltersApplier applier = new ToolsOutputFiltersApplier(service, List.of(artifact), cache);
+
+      String response = """
+            {
+              "users": [
+                {
+                  "name": "Alice",
+                  "middleName": null,
+                  "tags": []
+                },
+                {
+                  "name": "Bob",
+                  "bio": "",
+                  "address": {}
+                }
+              ]
+            }
+            """;
+      String filtered = applier.applyFilter("compactTool", response);
+
+      JsonNode result = MAPPER.readTree(filtered);
+      assertTrue(result.has("users"));
+      JsonNode users = result.get("users");
+      assertTrue(users.isArray());
+      assertEquals(2, users.size());
+
+      assertEquals("Alice", users.get(0).get("name").asText());
+      assertFalse(users.get(0).has("middleName"));
+      assertFalse(users.get(0).has("tags"));
+
+      assertEquals("Bob", users.get(1).get("name").asText());
+      assertFalse(users.get(1).has("bio"));
+      assertFalse(users.get(1).has("address"));
+   }
+
+   @Test
+   void testCompactAfterJsonPatches() throws Exception {
+      String artifactContent = """
+            apiVersion: reshapr.io/v1alpha1
+            kind: ToolsOutputFilters
+            service:
+              name: Test API
+              version: '1.0.0'
+            filters:
+              patchAndCompact:
+                jsonPatches:
+                  - op: add
+                    path: /addedNull
+                    value: null
+                compact: true
+            """;
+      ServiceEntry service = new ServiceEntry("svc-1", "org-1", "Test API", "1.0.0", "REST", null);
+      ArtifactEntry artifact = new ArtifactEntry("art-1", "filters.yaml", null,
+            ArtifactEntryType.RESHAPR_TOOLS_OUTPUT_FILTERS, false, artifactContent);
+      WorkCache cache = new WorkCache(100);
+      ToolsOutputFiltersApplier applier = new ToolsOutputFiltersApplier(service, List.of(artifact), cache);
+
+      String response = "{\"name\":\"John\"}";
+      String filtered = applier.applyFilter("patchAndCompact", response);
+
+      JsonNode result = MAPPER.readTree(filtered);
+      assertTrue(result.has("name"));
+      assertFalse(result.has("addedNull")); // Patched null field was pruned by compact
+   }
+
+   @Test
+   void testCompactBeforeConvertToToon() throws Exception {
+      String artifactContent = """
+            apiVersion: reshapr.io/v1alpha1
+            kind: ToolsOutputFilters
+            service:
+              name: Test API
+              version: '1.0.0'
+            filters:
+              compactAndToon:
+                compact: true
+                convertToToon: true
+            """;
+      ServiceEntry service = new ServiceEntry("svc-1", "org-1", "Test API", "1.0.0", "REST", null);
+      ArtifactEntry artifact = new ArtifactEntry("art-1", "filters.yaml", null,
+            ArtifactEntryType.RESHAPR_TOOLS_OUTPUT_FILTERS, false, artifactContent);
+      WorkCache cache = new WorkCache(100);
+      ToolsOutputFiltersApplier applier = new ToolsOutputFiltersApplier(service, List.of(artifact), cache);
+
+      String response = "{\"name\":\"John\",\"bio\":\"\",\"middleName\":null}";
+      String filtered = applier.applyFilter("compactAndToon", response);
+
+      assertFalse(filtered.startsWith("{"));
+      assertTrue(filtered.contains("John"));
+      assertFalse(filtered.contains("bio"));
+      assertFalse(filtered.contains("middleName"));
+   }
+
+   @Test
+   void testNoCompactLeavesResponseUnchanged() throws Exception {
+      String artifactContent = """
+            apiVersion: reshapr.io/v1alpha1
+            kind: ToolsOutputFilters
+            service:
+              name: Test API
+              version: '1.0.0'
+            filters:
+              uncompactedTool:
+                jsonRetain:
+                  - /name
+                  - /middleName
+                  - /bio
+            """;
+      ServiceEntry service = new ServiceEntry("svc-1", "org-1", "Test API", "1.0.0", "REST", null);
+      ArtifactEntry artifact = new ArtifactEntry("art-1", "filters.yaml", null,
+            ArtifactEntryType.RESHAPR_TOOLS_OUTPUT_FILTERS, false, artifactContent);
+      WorkCache cache = new WorkCache(100);
+      ToolsOutputFiltersApplier applier = new ToolsOutputFiltersApplier(service, List.of(artifact), cache);
+
+      String response = "{\"name\":\"John\",\"middleName\":null,\"bio\":\"\"}";
+      String filtered = applier.applyFilter("uncompactedTool", response);
+
+      JsonNode result = MAPPER.readTree(filtered);
+      assertTrue(result.has("name"));
+      assertTrue(result.has("middleName"));
+      assertTrue(result.has("bio"));
+      assertTrue(result.get("middleName").isNull());
+      assertEquals("", result.get("bio").asText());
+   }
 }


### PR DESCRIPTION
## 📝 Description

Implements the `compact` response filter for `ToolsOutputFilters` artifacts.

The new filter recursively removes sparse JSON values (`null`, `""`, `[]`, `{}`) from MCP tool responses before they are returned to LLM clients. This helps reduce the number of unnecessary tokens sent to LLMs while preserving existing behavior for tools that do not enable the filter.

**Fixes #293**

---

## Design Notes

- `compact` recursively traverses the entire JSON tree.
- No path-based configuration is introduced; path-specific modifications remain the responsibility of `jsonPatches`.
- The filter has a single responsibility: removing sparse values.
- Existing behavior is preserved for tools that do not configure `compact`.

### Filter Pipeline

```text
jsonRetain
    ↓
jsonPatches
    ↓
compact
    ↓
convertToToon
```

---

## 🛠️ Changes

### `ToolsOutputFiltersApplier`

- Added support for the new `compact` filter.
- Integrated compaction into the existing output filter pipeline.
- Implemented recursive pruning for:
  - `null`
  - empty strings (`""`)
  - empty arrays (`[]`)
  - empty objects (`{}`)
- Uses iterator-based removal to safely avoid `ConcurrentModificationException`.
- Supports nested objects, nested arrays, and arbitrarily deep JSON structures.

### Schema

- Extended the `ToolsOutputFilters` schema to support the new `compact` configuration.

### Tests

Added unit tests covering:

- Null field pruning
- Empty string pruning
- Empty array pruning
- Empty object pruning
- Nested object compaction
- Nested array compaction
- Pipeline interaction with `jsonPatches`
- Pipeline interaction with `convertToToon`
- Backward compatibility for tools without `compact`

---

## ✅ Verification

Executed:

```bash
mvn test -Dtest=ToolsOutputFiltersApplierTest
```

- All existing tests continue to pass.
- All newly added tests pass successfully.