### PR TITLE
Configure Keycloak proxy headers for ngrok

### DIFF
--- a/dev/start-keycloak-docker.sh
+++ b/dev/start-keycloak-docker.sh
@@ -22,7 +22,7 @@ docker run -d --rm --name "${CONTAINER_NAME}" \
   -e KC_HOSTNAME_STRICT=false \
   -e KC_HTTP_ENABLED=true \
   "${KEYCLOAK_IMAGE}" \
-  start-dev --hostname "https://unvibrating-uncondoned-jessia.ngrok-free.dev" --import-realm --hostname-backchannel-dynamic true --features cimd
+  start-dev --hostname "https://unvibrating-uncondoned-jessia.ngrok-free.dev" --proxy-headers xforwarded --import-realm --hostname-backchannel-dynamic true --features cimd
 # start-dev --hostname "http://localhost:${HOST_PORT}" --import-realm --hostname-backchannel-dynamic true
 
 echo "Waiting for Keycloak to be ready ..."


### PR DESCRIPTION
## Summary

- configure the Keycloak development helper to process ngrok forwarded headers
- ensure public OAuth and OpenID Connect metadata advertises HTTPS endpoints
- preserve the existing ephemeral H2 database behavior

## Validation

- `bash -n dev/start-keycloak-docker.sh`
- restarted Keycloak successfully using the updated script
- verified that public authorization, token, JWKS, and registration endpoints use HTTPS

Fixes #313
