### PR TITLE
Make the CIMD ngrok URL configurable

### DIFF
--- a/dev/cimd-elicitation/README.md
+++ b/dev/cimd-elicitation/README.md
@@ -16,11 +16,19 @@ python3 -m http.server 8000
 
 #### Keycloak Configuration
 
-Use `start-keycloak-docker.sh` to start a local Keycloak instance on http://localhost:8888
-
-Make this Keycloak available in HTTPS by using `ngrok`: 
+First, make Keycloak available in HTTPS by starting `ngrok` with your public domain:
 ```shell
-ngrok http 8888
+ngrok http 8888 --url <your-ngrok-domain>
+```
+
+In another terminal, export the matching public URL:
+```shell
+export RESHAPR_NGROK_URL="https://<your-ngrok-domain>"
+```
+
+Then start the local Keycloak instance on http://localhost:8888:
+```shell
+../start-keycloak-docker.sh
 ```
 
 Now checking the configuration of the different Keycloak realms (connect to the local Keycloak using `admin`/`admin`):
@@ -45,19 +53,20 @@ Check the `cimd-policy` in realm configuration:
 
 You should be able to authent using `laurent`/`laurent`:
 
-https://unvibrating-uncondoned-jessia.ngrok-free.dev/realms/3rdparty/protocol/openid-connect/auth?client_id=http://host.docker.internal:8000/metadata.json&response_type=code&redirect_uri=http://localhost:8000/callback&scope=openid
+https://<your-ngrok-domain>/realms/3rdparty/protocol/openid-connect/auth?client_id=http://host.docker.internal:8000/metadata.json&response_type=code&redirect_uri=http://localhost:8000/callback&scope=openid
 
 ## 2nd step: Run the full demonstration
 
 ### Pre-requisites
 
 * Have the Keycloak instance running (`../dev/start-keycloak-docker.sh`)
-* Have a Ngrok tunnel running (`ngrok http 8888`)
+* Have a Ngrok tunnel running (`ngrok http 8888 --url <your-ngrok-domain>`)
+* Have `RESHAPR_NGROK_URL="https://<your-ngrok-domain>"` exported in the current terminal
 * Have a Reshapr control plane + gateway running
 
 ### Load the Open Meteo with Elicitation example
 
-Check the `elicitation-example.sh` and adapt the `NGROK_ALIAS` value to your local ngrok tunnel.
+Export the same `RESHAPR_NGROK_URL` used to start Keycloak.
 
 Execute `./elicitation-example.sh`:
 ```shell

--- a/dev/cimd-elicitation/elicitation-example.sh
+++ b/dev/cimd-elicitation/elicitation-example.sh
@@ -1,11 +1,12 @@
-export NGROK_ALIAS=unvibrating-uncondoned-jessia.ngrok-free.dev
+: "${RESHAPR_NGROK_URL:?Set RESHAPR_NGROK_URL to your public ngrok URL}"
+RESHAPR_NGROK_URL="${RESHAPR_NGROK_URL%/}"
 
 reshapr login -s http://localhost:5555 -u admin -p password
 
 export ELICITATION_ID=`reshapr secret create-elicitation backend-elicitation --oc reshapr-proxy \
   --ocs 4JKqglcdCa0tzLCJc1rzNhdOwqw5N2De \
-  --oae https://$NGROK_ALIAS/realms/backend/protocol/openid-connect/auth \
-  --ote https://$NGROK_ALIAS/realms/backend/protocol/openid-connect/token -o json | jq -r .id`
+  --oae "${RESHAPR_NGROK_URL}/realms/backend/protocol/openid-connect/auth" \
+  --ote "${RESHAPR_NGROK_URL}/realms/backend/protocol/openid-connect/token" -o json | jq -r .id`
 
 echo "ELICITATION_ID: $ELICITATION_ID"
 
@@ -14,8 +15,8 @@ export SERVICE_ID=`reshapr import -u https://raw.githubusercontent.com/open-mete
 echo "SERVICE_ID: $SERVICE_ID"
 
 export CONFIGPLAN_ID=`reshapr config create-oauth 'with-elicitation' -s $SERVICE_ID --bs $ELICITATION_ID --be https://api.open-meteo.com \
-  --oas "[\"https://$NGROK_ALIAS/realms/3rdparty\"]" \
-  --oju "https://$NGROK_ALIAS/realms/3rdparty/protocol/openid-connect/certs" \
+  --oas "[\"${RESHAPR_NGROK_URL}/realms/3rdparty\"]" \
+  --oju "${RESHAPR_NGROK_URL}/realms/3rdparty/protocol/openid-connect/certs" \
   --osc '["openid"]' -o json | jq -r .id`
 
 echo "CONFIGPLAN_ID: $CONFIGPLAN_ID"

--- a/dev/start-keycloak-docker.sh
+++ b/dev/start-keycloak-docker.sh
@@ -6,6 +6,8 @@ set -euo pipefail
 CONTAINER_NAME="${RESHAPR_KEYCLOAK_CONTAINER:-reshapr-keycloak-dev}"
 KEYCLOAK_IMAGE="${KEYCLOAK_IMAGE:-quay.io/keycloak/keycloak:26.6.0}"
 HOST_PORT="${KEYCLOAK_HOST_PORT:-8888}"
+: "${RESHAPR_NGROK_URL:?Set RESHAPR_NGROK_URL to your public ngrok URL}"
+RESHAPR_NGROK_URL="${RESHAPR_NGROK_URL%/}"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "${SCRIPT_DIR}"
@@ -22,7 +24,7 @@ docker run -d --rm --name "${CONTAINER_NAME}" \
   -e KC_HOSTNAME_STRICT=false \
   -e KC_HTTP_ENABLED=true \
   "${KEYCLOAK_IMAGE}" \
-  start-dev --hostname "https://unvibrating-uncondoned-jessia.ngrok-free.dev" --proxy-headers xforwarded --import-realm --hostname-backchannel-dynamic true --features cimd
+  start-dev --hostname "${RESHAPR_NGROK_URL}" --proxy-headers xforwarded --import-realm --hostname-backchannel-dynamic true --features cimd
 # start-dev --hostname "http://localhost:${HOST_PORT}" --import-realm --hostname-backchannel-dynamic true
 
 echo "Waiting for Keycloak to be ready ..."


### PR DESCRIPTION
## Summary

- require a shared `RESHAPR_NGROK_URL` for the CIMD development scripts
- derive the Keycloak hostname and reShapr OAuth endpoints from that URL
- normalize an optional trailing slash
- document the ngrok and environment setup without hard-coded domains
- preserve the ephemeral H2 database and forwarded-header behavior

## Dependency

This PR is stacked on #314. Once #314 is merged, this PR should be rebased and retargeted to `main`.

## Validation

- `bash -n dev/start-keycloak-docker.sh`
- `bash -n dev/cimd-elicitation/elicitation-example.sh`
- verified missing configuration fails before side effects
- `git diff --check`

Fixes #315
