### PR TITLE
feat: add java micro-benchmark for GrpcMcpToolConverter

### DIFF
--- a/benchmarks/.gitignore
+++ b/benchmarks/.gitignore
@@ -3,3 +3,4 @@ dependency-reduced-pom.xml
 
 # e2e benchmark outputs (k6 summaries, memory samples, logs)
 results-e2e-rest/
+results-*.json

--- a/benchmarks/run-grpc-converter-bench.sh
+++ b/benchmarks/run-grpc-converter-bench.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Pre-requisites:
+# - Build proxy first: cd .. && ./mvnw install -DskipTests -pl proxy -am
+# - Package the benchmark jar: mvn clean package
+# - (optional) install jq for result summarization: sudo apt install jq
+
+set -e
+
+# Run the benchmark and save the results to a JSON file
+java --enable-preview -jar target/benchmarks.jar GrpcGetCallResponseBenchmark \
+     -prof gc -rf json -rff results-grpc-converter.json
+
+# Tip: to limit the number of scenario and parameters, you can use the -p option to specify parameters. For example:
+#java --enable-preview -jar target/benchmarks.jar "GrpcGetCallResponseBenchmark.warmCacheFreshConverter" \
+#    -p refStyle=EXTERNAL -p specSize=SMALL -prof gc -rf json -rff results-grpc-converter.json
+
+# Available parameters for this benchmark:
+# - operationCount: 6,30,80
+# - specSize: SMALL,MEDIUM,LARGE
+# - refStyle: EXTERNAL,INLINE
+
+# Summarize the results in a human-readable table format
+echo ""
+echo "-------------------------------------"
+echo "gRPC Converter Benchmark Results:"
+echo "-------------------------------------"
+./summarize.sh results-grpc-converter.json

--- a/benchmarks/src/main/java/io/reshapr/benchmarks/grpc/GrpcGetCallResponseBenchmark.java
+++ b/benchmarks/src/main/java/io/reshapr/benchmarks/grpc/GrpcGetCallResponseBenchmark.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright The Reshapr Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.reshapr.benchmarks.grpc;
+
+import io.reshapr.benchmarks.proxy.NaiveGrpcProxyService;
+import io.reshapr.proxy.mcp.McpSchema;
+import io.reshapr.proxy.mcp.WorkCache;
+import io.reshapr.proxy.mcp.converters.GrpcMcpToolConverter;
+import io.reshapr.proxy.mcp.converters.McpToolConverter;
+import io.reshapr.proxy.proxy.GrpcProxyService;
+import io.reshapr.proxy.registry.ArtifactEntry;
+import io.reshapr.proxy.registry.ArtifactEntryType;
+import io.reshapr.proxy.registry.ConfigurationEntry;
+import io.reshapr.proxy.registry.ExpositionEntry;
+import io.reshapr.proxy.registry.OperationEntry;
+import io.reshapr.proxy.registry.ServiceEntry;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Micro-benchmark for {@code GrpcMcpToolConverter.getCallResponse()}.
+ *
+ * <p>Axes:</p>
+ * <ul>
+ *   <li>{@code operationCount}: 6 (few), 30 (medium), 80 (many) operations in the spec</li>
+ *   <li>{@code specSize}: SMALL / MEDIUM / LARGE schema complexity (drives document byte size)</li>
+ *   <li>{@code refStyle}: INLINE (local refs) / EXTERNAL (parameters + schemas in attached YAML file)</li>
+ *   <li>cold vs warm {@link WorkCache} (dedicated benchmark methods)</li>
+ * </ul>
+ *
+ * <p>The {@link GrpcProxyService} is replaced by {@link NaiveGrpcProxyService} so no I/O is measured —
+ * only the conversion logic. Run with {@code -prof gc} to also capture per-op allocations.</p>
+ *
+ * @author laurent
+ */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Warmup(iterations = 3, time = 2)
+@Measurement(iterations = 5, time = 2)
+@Fork(value = 1, jvmArgsAppend = { "--enable-preview", "-Xms1g", "-Xmx1g" })
+public class GrpcGetCallResponseBenchmark {
+
+   private static final String ARTIFACT_ID = "artifact-grpc-1";
+
+   /** Shared, per-trial state: generated spec, exposition, stubbed proxy and a pre-warmed converter. */
+   @State(Scope.Benchmark)
+   public static class BenchState {
+
+      @Param({ "6", "30", "80" })
+      public int operationCount;
+
+      @Param({ "SMALL", "MEDIUM", "LARGE" })
+      public String specSize;
+
+      @Param({ "INLINE", "EXTERNAL" })
+      public String refStyle;
+
+      ObjectMapper mapper;
+      GrpcProxyService proxyStub;
+      ExpositionEntry exposition;
+      ConfigurationEntry configuration;
+      OperationEntry operation;
+      Map<String, Object> argumentsTemplate;
+
+      WorkCache warmCache;
+      GrpcMcpToolConverter warmConverter;
+
+      @Setup(Level.Trial)
+      public void setupTrial() {
+         mapper = new ObjectMapper();
+         proxyStub = new NaiveGrpcProxyService();
+
+         // Generate the synthetic gRPC Protobuf specification.
+         GrpcSpecGenerator.GeneratedSpec generated = new GrpcSpecGenerator().generate(operationCount,
+               GrpcSpecGenerator.Complexity.valueOf(specSize),
+               GrpcSpecGenerator.RefStyle.valueOf(refStyle));
+
+         System.out.printf("%n>>> Generated gRPC spec: %d operations, complexity %s, %s%n",
+               operationCount, specSize, refStyle);
+
+         ArtifactEntry artifact = new ArtifactEntry(ARTIFACT_ID, "synthetic.proto",
+               "synthetic.proto", ArtifactEntryType.PROTOBUF_DESCRIPTOR, true, generated.base64DescriptorSet());
+
+         operation = new OperationEntry(generated.benchmarkedOperation(), "UNARY", null, null, null);
+
+         ServiceEntry service = new ServiceEntry("svc-grpc-1", "reshapr", generated.serviceName(), "1.0.0", "GRPC", List.of(operation));
+         configuration = new ConfigurationEntry("cfg-grpc-1", "synthetic-grpc", "grpc://localhost:1",
+               1000L, null, null, null, null, null);
+         exposition = new ExpositionEntry("expo-grpc-1", "synthetic-grpc", service, configuration, artifact,
+               List.of());
+
+         // Build the arguments template matching the benchmarked operation parameters.
+         argumentsTemplate = new HashMap<>();
+         int fields = GrpcSpecGenerator.Complexity.valueOf(specSize).fieldsPerMessage;
+         for (int i = 1; i <= fields; i++) {
+            argumentsTemplate.put("field_" + i, "value_" + i);
+         }
+
+         // Build a converter with a pre-warmed cache for the 'warm' benchmarks.
+         warmCache = new WorkCache(1000);
+         warmConverter = new GrpcMcpToolConverter(exposition, warmCache, mapper, proxyStub);
+         McpToolConverter.Response response = warmConverter.getCallResponse(operation, configuration,
+               newRequest(), newHeaders());
+         if (response == null || response.isFault()) {
+            throw new IllegalStateException("Sanity check failed: unexpected response " + response);
+         }
+      }
+
+      public McpSchema.SimpleRequest newRequest() {
+         return new McpSchema.SimpleRequest(operation.name(), argumentsTemplate);
+      }
+
+      public Map<String, List<String>> newHeaders() {
+         return Map.of("x-reshapr-key", List.of("dummy"));
+      }
+   }
+
+   /**
+    * Cold cache scenario: empty WorkCache. The converter is newly instantiated per call
+    * and MUST parse the Protobuf descriptor from the base64 string.
+    */
+   @Benchmark
+   public McpToolConverter.Response coldCache(BenchState bench) {
+      WorkCache emptyCache = new WorkCache(100);
+      GrpcMcpToolConverter converter = new GrpcMcpToolConverter(bench.exposition, emptyCache, bench.mapper, bench.proxyStub);
+      return converter.getCallResponse(bench.operation, bench.configuration, bench.newRequest(), bench.newHeaders());
+   }
+
+   /**
+    * Warm cache, pre-warmed converter scenario: the WorkCache is pre-populated with the parsed
+    * Descriptor objects, and the converter instance itself is reused across calls.
+    * This is the absolute fast-path.
+    */
+   @Benchmark
+   public McpToolConverter.Response warmCache(BenchState bench) {
+      return bench.warmConverter.getCallResponse(bench.operation, bench.configuration, bench.newRequest(), bench.newHeaders());
+   }
+
+   /**
+    * Warm cache, fresh converter scenario: the WorkCache is pre-populated, but a fresh converter
+    * instance is created per call. This mimics production behavior where ToolCallExecutor
+    * uses `buildMcpToolConverter()` which instantiates a new converter per request (reusing the cache).
+    */
+   @Benchmark
+   public McpToolConverter.Response warmCacheFreshConverter(BenchState bench) {
+      GrpcMcpToolConverter converter = new GrpcMcpToolConverter(bench.exposition, bench.warmCache, bench.mapper, bench.proxyStub);
+      return converter.getCallResponse(bench.operation, bench.configuration, bench.newRequest(), bench.newHeaders());
+   }
+}

--- a/benchmarks/src/main/java/io/reshapr/benchmarks/grpc/GrpcSpecGenerator.java
+++ b/benchmarks/src/main/java/io/reshapr/benchmarks/grpc/GrpcSpecGenerator.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright The Reshapr Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.reshapr.benchmarks.grpc;
+
+import com.google.protobuf.DescriptorProtos;
+import com.google.protobuf.DescriptorProtos.DescriptorProto;
+import com.google.protobuf.DescriptorProtos.FieldDescriptorProto;
+import com.google.protobuf.DescriptorProtos.FileDescriptorProto;
+import com.google.protobuf.DescriptorProtos.FileDescriptorSet;
+import com.google.protobuf.DescriptorProtos.MethodDescriptorProto;
+import com.google.protobuf.DescriptorProtos.ServiceDescriptorProto;
+
+import java.util.Base64;
+import java.util.List;
+
+/**
+ * Generates synthetic gRPC Protobuf specifications (FileDescriptorSet in base64) with a controllable
+ * number of operations, schema complexity, and reference style (inline vs external file), so that
+ * benchmark scenarios are reproducible.
+ *
+ * <p>The generated spec always contains a benchmarked unary operation 
+ * {@link GeneratedSpec#benchmarkedOperation()} (e.g. "Method0").</p>
+ *
+ * @author laurent
+ */
+public class GrpcSpecGenerator {
+
+   /** Schema complexity presets driving the byte-size of the generated document. */
+   public enum Complexity {
+      SMALL(5),
+      MEDIUM(20),
+      LARGE(50);
+
+      final int fieldsPerMessage;
+
+      Complexity(int fieldsPerMessage) {
+         this.fieldsPerMessage = fieldsPerMessage;
+      }
+   }
+
+   /** Where parameter/schema definitions live. */
+   public enum RefStyle {
+      /** Everything defined in the same .proto file (single FileDescriptorProto). */
+      INLINE,
+      /** Shared messages are defined in an imported external .proto file (multiple FileDescriptorProtos). */
+      EXTERNAL
+   }
+
+   /**
+    * Result of a generation: the main FileDescriptorSet encoded in base64, and the metadata needed
+    * by the benchmark (operation name).
+    */
+   public record GeneratedSpec(
+         String base64DescriptorSet,
+         String benchmarkedOperation,
+         String serviceName) {
+   }
+
+   public static final String PACKAGE_NAME = "io.reshapr.benchmarks.synthetic";
+   public static final String SERVICE_NAME = "SyntheticService";
+   private static final String MAIN_FILE_NAME = "synthetic_main.proto";
+   private static final String IMPORT_FILE_NAME = "synthetic_common.proto";
+
+   /**
+    * Generate a gRPC Protobuf spec.
+    * @param operationCount Total number of operations (methods) in the service.
+    * @param complexity Schema complexity preset (number of fields per message).
+    * @param refStyle Inline messages or external file references.
+    * @return The generated spec plus benchmark metadata.
+    */
+   public GeneratedSpec generate(int operationCount, Complexity complexity, RefStyle refStyle) {
+      FileDescriptorSet.Builder fdsBuilder = FileDescriptorSet.newBuilder();
+
+      FileDescriptorProto.Builder mainFileBuilder = FileDescriptorProto.newBuilder()
+            .setName(MAIN_FILE_NAME)
+            .setPackage(PACKAGE_NAME)
+            .setSyntax("proto3");
+
+      FileDescriptorProto.Builder importFileBuilder = null;
+      if (refStyle == RefStyle.EXTERNAL) {
+         importFileBuilder = FileDescriptorProto.newBuilder()
+               .setName(IMPORT_FILE_NAME)
+               .setPackage(PACKAGE_NAME)
+               .setSyntax("proto3");
+         mainFileBuilder.addDependency(IMPORT_FILE_NAME);
+      }
+
+      ServiceDescriptorProto.Builder serviceBuilder = ServiceDescriptorProto.newBuilder()
+            .setName(SERVICE_NAME);
+
+      for (int i = 0; i < operationCount; i++) {
+         String reqName = "RequestMessage" + i;
+         String resName = "ResponseMessage" + i;
+         String methodName = "Method" + i;
+
+         // For EXTERNAL, put the Request and Response messages in the imported file
+         FileDescriptorProto.Builder targetFileBuilder = (refStyle == RefStyle.EXTERNAL) ? importFileBuilder : mainFileBuilder;
+
+         targetFileBuilder.addMessageType(buildMessage(reqName, complexity));
+         targetFileBuilder.addMessageType(buildMessage(resName, complexity));
+
+         serviceBuilder.addMethod(MethodDescriptorProto.newBuilder()
+               .setName(methodName)
+               .setInputType("." + PACKAGE_NAME + "." + reqName)
+               .setOutputType("." + PACKAGE_NAME + "." + resName)
+               .build());
+      }
+
+      mainFileBuilder.addService(serviceBuilder);
+
+      // Add the files to the descriptor set. If EXTERNAL, add the imported one first.
+      if (refStyle == RefStyle.EXTERNAL) {
+         fdsBuilder.addFile(importFileBuilder.build());
+      }
+      fdsBuilder.addFile(mainFileBuilder.build());
+
+      String base64DescriptorSet = Base64.getEncoder().encodeToString(fdsBuilder.build().toByteArray());
+
+      // Method0 is always present since operationCount >= 1. We benchmark Method0.
+      return new GeneratedSpec(base64DescriptorSet, "Method0", PACKAGE_NAME + "." + SERVICE_NAME);
+   }
+
+   private DescriptorProto buildMessage(String name, Complexity complexity) {
+      DescriptorProto.Builder msgBuilder = DescriptorProto.newBuilder().setName(name);
+      for (int i = 1; i <= complexity.fieldsPerMessage; i++) {
+         msgBuilder.addField(FieldDescriptorProto.newBuilder()
+               .setName("field_" + i)
+               .setNumber(i)
+               .setType(FieldDescriptorProto.Type.TYPE_STRING)
+               .setLabel(FieldDescriptorProto.Label.LABEL_OPTIONAL)
+               .setJsonName("field_" + i)
+               .build());
+      }
+      return msgBuilder.build();
+   }
+}

--- a/benchmarks/src/main/java/io/reshapr/benchmarks/proxy/NaiveGrpcProxyService.java
+++ b/benchmarks/src/main/java/io/reshapr/benchmarks/proxy/NaiveGrpcProxyService.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright The Reshapr Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.reshapr.benchmarks.proxy;
+
+import io.reshapr.proxy.mcp.state.UserSecretStore;
+import io.reshapr.proxy.proxy.BackendResponse;
+import io.reshapr.proxy.proxy.GrpcProxyService;
+import io.reshapr.proxy.registry.ConfigurationEntry;
+import io.reshapr.proxy.secret.SecretReferenceResolver;
+
+import com.google.protobuf.Descriptors;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A naive {@link GrpcProxyService} stub that never performs any I/O: it always returns the very
+ * same canned response. This isolates the benchmark on the converter logic only.
+ * @author laurent
+ */
+public class NaiveGrpcProxyService extends GrpcProxyService {
+
+   private static final byte[] CANNED_BODY = "{\"status\":\"ok\",\"id\":\"42\"}".getBytes(StandardCharsets.UTF_8);
+
+   public NaiveGrpcProxyService() {
+      super(new SecretReferenceResolver(List.of()), new UserSecretStore(null));
+   }
+
+   @Override
+   public BackendResponse callBackend(ConfigurationEntry configuration, Descriptors.MethodDescriptor md,
+                                      Map<String, List<String>> headers, String body) throws IOException {
+      return new BackendResponse(0, CANNED_BODY, Map.of()); // 0 is gRPC OK status
+   }
+}


### PR DESCRIPTION
# Description
This PR introduces a JMH micro-benchmark suite for the `GrpcMcpToolConverter.getCallResponse()` logic to establish a CPU and Memory allocation performance baseline, addressing #339.

### Changes Included:
1. **`GrpcSpecGenerator`**: Synthesizes gRPC `FileDescriptorSet`s on the fly using `protobuf-java` builders, enabling us to dynamically test different schema complexities, method counts, and inline vs. external references without manual `.proto` compilation.
2. **`GrpcGetCallResponseBenchmark`**: A comprehensive JMH suite testing `GrpcMcpToolConverter.getCallResponse()` across three distinct cache states:
   - `coldCache`: Starts with an empty `WorkCache` (measures full parsing cost).
   - `warmCache`: Starts with a pre-warmed `WorkCache` and reuses the converter instance (absolute fast path).
   - `warmCacheFreshConverter`: Starts with a pre-warmed cache but spins up a fresh converter per invocation (mimics production behavior).
3. **`NaiveGrpcProxyService`**: A stubbed backend proxy service to completely isolate network I/O, ensuring the benchmark strictly measures parsing and conversion overhead.
4. **Runner Script**: Added `run-grpc-converter-bench.sh` to execute the benchmark with `-prof gc` and stream results to JSON.

Fixes #339 
