### PR TITLE
feat(web-ui): add organization membership management

### DIFF
--- a/control-plane/src/main/java/io/reshapr/ctrl/repository/UserRepository.java
+++ b/control-plane/src/main/java/io/reshapr/ctrl/repository/UserRepository.java
@@ -37,6 +37,15 @@ public class UserRepository implements PanacheRepository<User> {
    }
 
    /**
+    * Finds a user by their email.
+    * @param email the email of the user to find
+    * @return the User entity if found, otherwise null
+    */
+   public User findByEmail(String email) {
+      return find("email", email).firstResult();
+   }
+
+   /**
     * Adds a new user to the repository.
     * If the user has a password, it hashes the password before persisting.
     * @param user the User entity to add

--- a/control-plane/src/main/java/io/reshapr/ctrl/rest/v1/MemberDTO.java
+++ b/control-plane/src/main/java/io/reshapr/ctrl/rest/v1/MemberDTO.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright The Reshapr Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.reshapr.ctrl.rest.v1;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+/**
+ * DTO for representing a member of an organization.
+ * @param username
+ * @param email
+ * @param firstname
+ * @param lastname
+ */
+@RegisterForReflection
+public record MemberDTO(
+      String username,
+      String email,
+      String firstname,
+      String lastname) {
+}

--- a/control-plane/src/main/java/io/reshapr/ctrl/rest/v1/MemberRequestDTO.java
+++ b/control-plane/src/main/java/io/reshapr/ctrl/rest/v1/MemberRequestDTO.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright The Reshapr Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.reshapr.ctrl.rest.v1;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+/**
+ * DTO for requesting to add a member to an organization.
+ * @param email
+ */
+@RegisterForReflection
+public record MemberRequestDTO(
+      @NotBlank
+      @Email
+      String email) {
+}

--- a/control-plane/src/main/java/io/reshapr/ctrl/rest/v1/OrganizationResource.java
+++ b/control-plane/src/main/java/io/reshapr/ctrl/rest/v1/OrganizationResource.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright The Reshapr Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.reshapr.ctrl.rest.v1;
+
+import io.reshapr.ctrl.model.Organization;
+import io.reshapr.ctrl.model.User;
+import io.reshapr.ctrl.repository.OrganizationRepository;
+import io.reshapr.ctrl.repository.UserRepository;
+
+import io.quarkus.security.Authenticated;
+import io.quarkus.security.identity.SecurityIdentity;
+import io.smallrye.common.annotation.RunOnVirtualThread;
+import jakarta.transaction.Transactional;
+import jakarta.validation.Valid;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import org.jboss.logging.Logger;
+
+import java.util.List;
+
+/**
+ * Resource for organization operations in the public API (for end users).
+ */
+@RunOnVirtualThread
+@Path("/api/v1/organizations")
+@Authenticated
+public class OrganizationResource {
+
+   /** Get a JBoss logging logger. */
+   private final Logger logger = Logger.getLogger(getClass());
+
+   private final UserRepository userRepository;
+   private final OrganizationRepository organizationRepository;
+
+   public OrganizationResource(UserRepository userRepository, OrganizationRepository organizationRepository) {
+      this.userRepository = userRepository;
+      this.organizationRepository = organizationRepository;
+   }
+
+   @GET
+   @Path("/{organizationName}/members")
+   @Produces(MediaType.APPLICATION_JSON)
+   public Response getMembers(@Context SecurityIdentity securityIdentity, @PathParam("organizationName") String organizationName) {
+      String username = securityIdentity.getPrincipal().getName();
+      
+      Organization organization = organizationRepository.findByName(organizationName);
+      if (organization == null) {
+         return Response.status(Response.Status.NOT_FOUND).entity("Organization not found").build();
+      }
+      
+      // Only the owner is allowed to manage/view members.
+      if (organization.owner == null || !organization.owner.username.equals(username)) {
+         return Response.status(Response.Status.FORBIDDEN).entity("Only the owner can view members").build();
+      }
+
+      List<MemberDTO> members = organization.members.stream()
+            .map(u -> new MemberDTO(u.username, u.email, u.firstname, u.lastname))
+            .toList();
+
+      return Response.ok(members).build();
+   }
+
+   @POST
+   @Path("/{organizationName}/members")
+   @Produces(MediaType.APPLICATION_JSON)
+   @Transactional
+   public Response addMember(@Context SecurityIdentity securityIdentity, @PathParam("organizationName") String organizationName, @Valid MemberRequestDTO memberRequest) {
+      String username = securityIdentity.getPrincipal().getName();
+      
+      Organization organization = organizationRepository.findByName(organizationName);
+      if (organization == null) {
+         return Response.status(Response.Status.NOT_FOUND).entity("Organization not found").build();
+      }
+
+      if (organization.owner == null || !organization.owner.username.equals(username)) {
+         return Response.status(Response.Status.FORBIDDEN).entity("Only the owner can add members").build();
+      }
+
+      User targetUser = userRepository.findByEmail(memberRequest.email());
+      if (targetUser == null) {
+         return Response.status(Response.Status.BAD_REQUEST).entity("This email address does not match any existing user account").build();
+      }
+
+      if (!targetUser.organizations.contains(organization)) {
+         targetUser.organizations.add(organization);
+         if (targetUser.defaultOrganization == null) {
+            targetUser.defaultOrganization = organization;
+         }
+         userRepository.persistAndFlush(targetUser);
+      }
+      
+      // We don't want to expose target user's details completely, returning just success status
+      return Response.ok().entity("User added as a member").build();
+   }
+
+   @DELETE
+   @Path("/{organizationName}/members/{email}")
+   @Produces(MediaType.APPLICATION_JSON)
+   @Transactional
+   public Response removeMember(@Context SecurityIdentity securityIdentity, @PathParam("organizationName") String organizationName, @PathParam("email") String email) {
+      String username = securityIdentity.getPrincipal().getName();
+      
+      Organization organization = organizationRepository.findByName(organizationName);
+      if (organization == null) {
+         return Response.status(Response.Status.NOT_FOUND).entity("Organization not found").build();
+      }
+
+      if (organization.owner == null || !organization.owner.username.equals(username)) {
+         return Response.status(Response.Status.FORBIDDEN).entity("Only the owner can remove members").build();
+      }
+
+      // Check if trying to remove the owner
+      User targetUser = userRepository.findByEmail(email);
+      if (targetUser == null) {
+         // Doesn't exist, safely ignore or return 404
+         return Response.status(Response.Status.NOT_FOUND).entity("User not found").build();
+      }
+
+      if (targetUser.username.equals(organization.owner.username)) {
+         return Response.status(Response.Status.BAD_REQUEST).entity("Cannot remove the owner of the organization").build();
+      }
+
+      if (targetUser.organizations.contains(organization)) {
+         targetUser.organizations.remove(organization);
+         if (targetUser.defaultOrganization != null && targetUser.defaultOrganization.name.equals(organization.name)) {
+            targetUser.defaultOrganization = targetUser.organizations.isEmpty() ? null : targetUser.organizations.get(0);
+         }
+         userRepository.persistAndFlush(targetUser);
+      }
+
+      return Response.noContent().build();
+   }
+}

--- a/control-plane/src/main/java/io/reshapr/ctrl/rest/v1/UserOrganizationDTO.java
+++ b/control-plane/src/main/java/io/reshapr/ctrl/rest/v1/UserOrganizationDTO.java
@@ -27,5 +27,6 @@ import io.quarkus.runtime.annotations.RegisterForReflection;
 public record UserOrganizationDTO(
       String name,
       String description,
-      String icon) {
+      String icon,
+      boolean isOwner) {
 }

--- a/control-plane/src/main/java/io/reshapr/ctrl/rest/v1/UserProfileResource.java
+++ b/control-plane/src/main/java/io/reshapr/ctrl/rest/v1/UserProfileResource.java
@@ -96,7 +96,9 @@ public class UserProfileResource {
    private UserProfileDTO getUserProfile(User user) {
       return new UserProfileDTO(user.firstname, user.lastname,
             user.defaultOrganization != null ? user.defaultOrganization.name : null,
-            v1Mappers.toResource(user.organizations));
+            user.organizations.stream().map(o -> new UserOrganizationDTO(
+                  o.name, o.description, o.icon, o.owner != null && o.owner.username.equals(user.username)
+            )).toList());
    }
 }
 

--- a/control-plane/src/main/resources/db/dev-data/V1.0.2__dev-data.sql
+++ b/control-plane/src/main/resources/db/dev-data/V1.0.2__dev-data.sql
@@ -9,6 +9,9 @@ update users set default_organization_id = '1' where id = '1';
 update users set default_organization_id = '2' where id = '2';
 update users set default_organization_id = '3' where id = '3';
 
+insert into users_organizations (members_id, organizations_id) values ('2', '2');
+insert into users_organizations (members_id, organizations_id) values ('3', '3');
+
 insert into api_tokens (id, name, token, valid_until, user_id, organization_id) values ('1', 'Dev token', 'my-super-secret-token', '2026-12-24 23:59:59', '1', 'reshapr');
 insert into api_tokens (id, name, token, valid_until, user_id, organization_id) values ('2', 'Acme token', 'my-super-secret-token', '2026-12-24 23:59:59', '2', 'acme');
 

--- a/control-plane/src/test/java/io/reshapr/ctrl/rest/v1/OrganizationResourceTest.java
+++ b/control-plane/src/test/java/io/reshapr/ctrl/rest/v1/OrganizationResourceTest.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright The Reshapr Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.reshapr.ctrl.rest.v1;
+
+import io.reshapr.ctrl.model.Organization;
+import io.reshapr.ctrl.model.User;
+import io.reshapr.ctrl.repository.OrganizationRepository;
+import io.reshapr.ctrl.repository.UserRepository;
+
+import io.quarkus.security.identity.SecurityIdentity;
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.security.Principal;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class OrganizationResourceTest {
+
+   private OrganizationResource organizationResource;
+   private String currentUsername;
+   private User foundUserByEmail;
+   private Organization foundOrgByName;
+
+   @BeforeEach
+   public void setup() {
+      UserRepository stubUserRepository = new UserRepository() {
+         @Override
+         public User findByEmail(String email) {
+            return foundUserByEmail;
+         }
+         @Override
+         public void persistAndFlush(User entity) {
+            // Do nothing
+         }
+      };
+
+      OrganizationRepository stubOrganizationRepository = new OrganizationRepository() {
+         @Override
+         public Organization findByName(String name) {
+            return foundOrgByName;
+         }
+      };
+
+      organizationResource = new OrganizationResource(stubUserRepository, stubOrganizationRepository);
+   }
+
+   @Test
+   public void testGetMembersAsOwner() {
+      currentUsername = "owner";
+
+      User ownerUser = new User();
+      ownerUser.username = "owner";
+
+      User memberUser = new User();
+      memberUser.username = "member";
+      memberUser.email = "member@test.com";
+
+      Organization org = new Organization();
+      org.name = "my-org";
+      org.owner = ownerUser;
+      org.members = List.of(ownerUser, memberUser);
+
+      foundOrgByName = org;
+
+      Response response = organizationResource.getMembers(createStubIdentity(), "my-org");
+      assertEquals(200, response.getStatus());
+
+      List<MemberDTO> returnedMembers = (List<MemberDTO>) response.getEntity();
+      assertEquals(2, returnedMembers.size());
+      assertEquals("owner", returnedMembers.get(0).username());
+      assertEquals("member", returnedMembers.get(1).username());
+   }
+
+   @Test
+   public void testGetMembersAsNonOwner() {
+      currentUsername = "not-owner";
+
+      User ownerUser = new User();
+      ownerUser.username = "owner";
+
+      Organization org = new Organization();
+      org.name = "my-org";
+      org.owner = ownerUser;
+      org.members = List.of(ownerUser);
+
+      foundOrgByName = org;
+
+      Response response = organizationResource.getMembers(createStubIdentity(), "my-org");
+      assertEquals(403, response.getStatus());
+   }
+
+   @Test
+   public void testAddMemberAsOwner() {
+      currentUsername = "owner";
+
+      User ownerUser = new User();
+      ownerUser.username = "owner";
+
+      Organization org = new Organization();
+      org.name = "my-org";
+      org.owner = ownerUser;
+
+      User newMember = new User();
+      newMember.username = "new-member";
+      newMember.email = "new@test.com";
+      newMember.organizations = new ArrayList<>();
+
+      foundOrgByName = org;
+      foundUserByEmail = newMember;
+
+      MemberRequestDTO request = new MemberRequestDTO("new@test.com");
+      Response response = organizationResource.addMember(createStubIdentity(), "my-org", request);
+      
+      assertEquals(200, response.getStatus());
+      assertEquals(1, newMember.organizations.size());
+      assertEquals(org, newMember.organizations.get(0));
+   }
+
+   @Test
+   public void testAddMemberNotFound() {
+      currentUsername = "owner";
+
+      User ownerUser = new User();
+      ownerUser.username = "owner";
+
+      Organization org = new Organization();
+      org.name = "my-org";
+      org.owner = ownerUser;
+
+      foundOrgByName = org;
+      foundUserByEmail = null;
+
+      MemberRequestDTO request = new MemberRequestDTO("nonexistent@test.com");
+      Response response = organizationResource.addMember(createStubIdentity(), "my-org", request);
+      
+      assertEquals(400, response.getStatus());
+   }
+
+   @Test
+   public void testRemoveMemberAsOwner() {
+      currentUsername = "owner";
+
+      User ownerUser = new User();
+      ownerUser.username = "owner";
+
+      Organization org = new Organization();
+      org.name = "my-org";
+      org.owner = ownerUser;
+
+      User existingMember = new User();
+      existingMember.username = "member";
+      existingMember.email = "member@test.com";
+      existingMember.organizations = new ArrayList<>(List.of(org));
+
+      foundOrgByName = org;
+      foundUserByEmail = existingMember;
+
+      Response response = organizationResource.removeMember(createStubIdentity(), "my-org", "member@test.com");
+      
+      assertEquals(204, response.getStatus());
+      assertEquals(0, existingMember.organizations.size());
+   }
+
+   private SecurityIdentity createStubIdentity() {
+      return (SecurityIdentity) java.lang.reflect.Proxy.newProxyInstance(
+            OrganizationResourceTest.class.getClassLoader(),
+            new Class<?>[]{SecurityIdentity.class},
+            (proxy, method, args) -> {
+               if ("getPrincipal".equals(method.getName())) {
+                  return (Principal) () -> currentUsername;
+               }
+               return null;
+            }
+      );
+   }
+}

--- a/web-ui/src/lib/stores/auth.svelte.ts
+++ b/web-ui/src/lib/stores/auth.svelte.ts
@@ -32,6 +32,9 @@ function createAuthStore() {
   const isAdmin = $derived(user?.org === 'reshapr');
   const currentOrg = $derived(user?.org ?? '');
   const hasMultipleOrgs = $derived(profile? profile.organizations.length > 1 : false);
+  const isOwnerOfCurrentOrg = $derived(
+    profile?.organizations.find(o => o.name === currentOrg)?.isOwner ?? false
+  );
 
   /** Compute user initials from username (first 2 chars uppercased). */
   const initials = $derived(
@@ -49,6 +52,7 @@ function createAuthStore() {
     get organizations() { return profile?.organizations; },
     get currentOrg() { return currentOrg; },
     get hasMultipleOrgs() { return hasMultipleOrgs; },
+    get isOwnerOfCurrentOrg() { return isOwnerOfCurrentOrg; },
     get initials() { return initials; },
 
     setUser(profile: User | null) {

--- a/web-ui/src/lib/types.ts
+++ b/web-ui/src/lib/types.ts
@@ -43,6 +43,7 @@ export interface Organization {
   name: string;
   description: string | null;
   icon: string | null;
+  isOwner: boolean;
 }
 
 /** Authentication mode determined by the bootstrap configuration. */

--- a/web-ui/src/routes/(app)/+layout.svelte
+++ b/web-ui/src/routes/(app)/+layout.svelte
@@ -376,6 +376,7 @@
               <HugeiconsIcon icon={UserIcon} size={16} />
               <span>Account</span>
             </a>
+            {#if auth.isOwnerOfCurrentOrg}
             <a
               href="/organization"
               onclick={() => userMenuOpen = false}
@@ -384,6 +385,7 @@
               <HugeiconsIcon icon={Building01Icon} size={16} />
               <span>Organization Settings</span>
             </a>
+            {/if}
             <!-- Theme toggle: cycles Light → Dark → System. Keep the menu open so
                  the user can see the change and keep cycling. -->
             <button

--- a/web-ui/src/routes/(app)/+layout.svelte
+++ b/web-ui/src/routes/(app)/+layout.svelte
@@ -376,6 +376,14 @@
               <HugeiconsIcon icon={UserIcon} size={16} />
               <span>Account</span>
             </a>
+            <a
+              href="/organization"
+              onclick={() => userMenuOpen = false}
+              class="flex w-full items-center gap-2 px-3 py-2 text-sm text-popover-foreground hover:bg-accent transition-colors whitespace-nowrap"
+            >
+              <HugeiconsIcon icon={Building01Icon} size={16} />
+              <span>Organization Settings</span>
+            </a>
             <!-- Theme toggle: cycles Light → Dark → System. Keep the menu open so
                  the user can see the change and keep cycling. -->
             <button

--- a/web-ui/src/routes/(app)/organization/+page.svelte
+++ b/web-ui/src/routes/(app)/organization/+page.svelte
@@ -24,7 +24,8 @@
   import { Input } from '$lib/components/ui/input/index.js';
   import { Label } from '$lib/components/ui/label/index.js';
   import { onMount } from 'svelte';
-  import { Building01Icon, PlusSignIcon, Delete01Icon } from 'hugeicons-svelte';
+  import { HugeiconsIcon } from '@hugeicons/svelte';
+  import { Building01Icon, PlusSignIcon, Delete01Icon } from '@hugeicons/core-free-icons';
   import ConfirmDialog from '$lib/components/ConfirmDialog.svelte';
 
   interface MemberDTO {
@@ -153,7 +154,7 @@
   {:else if !isOwner}
     <Alert.Root class="mb-6">
       <Alert.Title class="flex items-center gap-2">
-        <Building01Icon size={18} />
+        <HugeiconsIcon icon={Building01Icon} size={18} />
         {auth.user.org}
       </Alert.Title>
       <Alert.Description class="text-sm mt-2">
@@ -208,7 +209,7 @@
                           class="h-8 w-8 text-destructive"
                           onclick={() => { memberToRemove = member; isConfirmDialogOpen = true; }}
                         >
-                          <Delete01Icon size={16} />
+                          <HugeiconsIcon icon={Delete01Icon} size={16} />
                         </Button>
                       {/if}
                     </Table.Cell>
@@ -263,7 +264,7 @@
                 {#if isInviting}
                   Adding...
                 {:else}
-                  <PlusSignIcon size={16} class="mr-2" />
+                  <HugeiconsIcon icon={PlusSignIcon} size={16} class="mr-2" />
                   Add Member
                 {/if}
               </Button>

--- a/web-ui/src/routes/(app)/organization/+page.svelte
+++ b/web-ui/src/routes/(app)/organization/+page.svelte
@@ -1,0 +1,289 @@
+<!--
+  ~ Copyright The Reshapr Authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<script lang="ts">
+  import PageHeader from '$lib/components/PageHeader.svelte';
+  import { auth } from '$lib/stores/auth.svelte.js';
+  import * as Alert from '$lib/components/ui/alert/index.js';
+  import * as Card from '$lib/components/ui/card/index.js';
+  import * as Table from '$lib/components/ui/table/index.js';
+  import { Button } from '$lib/components/ui/button/index.js';
+  import { Input } from '$lib/components/ui/input/index.js';
+  import { Label } from '$lib/components/ui/label/index.js';
+  import { onMount } from 'svelte';
+  import { Building01Icon, PlusSignIcon, Delete01Icon } from 'hugeicons-svelte';
+  import ConfirmDialog from '$lib/components/ConfirmDialog.svelte';
+
+  interface MemberDTO {
+    username: string;
+    email: string;
+    firstname: string;
+    lastname: string;
+  }
+
+  let members = $state<MemberDTO[]>([]);
+  let isLoading = $state(true);
+  let errorMsg = $state<string | null>(null);
+  let isOwner = $state(true);
+
+  // Invite member state
+  let inviteEmail = $state('');
+  let isInviting = $state(false);
+  let inviteError = $state<string | null>(null);
+  let inviteSuccess = $state<string | null>(null);
+
+  // Remove member state
+  let memberToRemove = $state<MemberDTO | null>(null);
+  let isConfirmDialogOpen = $state(false);
+
+  async function fetchMembers() {
+    if (!auth.user?.org) return;
+
+    isLoading = true;
+    errorMsg = null;
+    isOwner = true;
+
+    try {
+      const res = await fetch(`/api/v1/organizations/${encodeURIComponent(auth.user.org)}/members`);
+      if (res.status === 403) {
+        isOwner = false;
+      } else if (!res.ok) {
+        throw new Error(await res.text());
+      } else {
+        members = await res.json();
+      }
+    } catch (e: any) {
+      errorMsg = e.message || 'Failed to fetch members.';
+    } finally {
+      isLoading = false;
+    }
+  }
+
+  async function addMember(e: Event) {
+    e.preventDefault();
+    if (!inviteEmail || !auth.user?.org) return;
+
+    isInviting = true;
+    inviteError = null;
+    inviteSuccess = null;
+
+    try {
+      const res = await fetch(`/api/v1/organizations/${encodeURIComponent(auth.user.org)}/members`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email: inviteEmail })
+      });
+
+      if (!res.ok) {
+        throw new Error(await res.text());
+      }
+
+      inviteSuccess = 'User successfully added to organization.';
+      inviteEmail = '';
+      await fetchMembers();
+    } catch (e: any) {
+      inviteError = e.message || 'Failed to add member.';
+    } finally {
+      isInviting = false;
+    }
+  }
+
+  async function removeMember() {
+    if (!memberToRemove || !auth.user?.org) return;
+
+    const res = await fetch(`/api/v1/organizations/${encodeURIComponent(auth.user.org)}/members/${encodeURIComponent(memberToRemove.email)}`, {
+      method: 'DELETE'
+    });
+
+    if (!res.ok) {
+      throw new Error(await res.text());
+    }
+
+    memberToRemove = null;
+    isConfirmDialogOpen = false;
+    await fetchMembers();
+  }
+
+  onMount(() => {
+    if (auth.user?.org) {
+      fetchMembers();
+    } else {
+      isLoading = false;
+    }
+  });
+
+  // Whenever the active org changes, re-fetch.
+  $effect(() => {
+    if (auth.user?.org) {
+      fetchMembers();
+    }
+  });
+</script>
+
+<svelte:head>
+  <title>Organization Settings — reShapr</title>
+</svelte:head>
+
+<div>
+  <PageHeader
+    title="Organization Settings"
+    subtitle="Manage members and settings for your current organization."
+  />
+
+  {#if !auth.user?.org}
+    <Alert.Root variant="destructive">
+      <Alert.Title>No organization selected</Alert.Title>
+      <Alert.Description class="text-sm">
+        Please select an organization from the sidebar or user menu.
+      </Alert.Description>
+    </Alert.Root>
+  {:else if !isOwner}
+    <Alert.Root class="mb-6">
+      <Alert.Title class="flex items-center gap-2">
+        <Building01Icon size={18} />
+        {auth.user.org}
+      </Alert.Title>
+      <Alert.Description class="text-sm mt-2">
+        You are a member of this organization, but only the owner can manage its settings and members.
+      </Alert.Description>
+    </Alert.Root>
+  {:else}
+    <div class="grid gap-6 lg:grid-cols-[1fr_300px]">
+      
+      <!-- Members List -->
+      <Card.Root>
+        <Card.Header>
+          <Card.Title class="text-lg">Members of {auth.user.org}</Card.Title>
+          <Card.Description>Manage who has access to this organization.</Card.Description>
+        </Card.Header>
+        <Card.Content>
+          {#if errorMsg}
+            <Alert.Root variant="destructive" class="mb-4">
+              <Alert.Title>Error</Alert.Title>
+              <Alert.Description class="text-sm">{errorMsg}</Alert.Description>
+            </Alert.Root>
+          {/if}
+
+          {#if isLoading}
+            <div class="text-sm text-muted-foreground p-4 text-center">Loading members...</div>
+          {:else}
+            <Table.Root>
+              <Table.Header>
+                <Table.Row>
+                  <Table.Head>Name</Table.Head>
+                  <Table.Head>Email</Table.Head>
+                  <Table.Head>Username</Table.Head>
+                  <Table.Head class="w-[80px] text-right"></Table.Head>
+                </Table.Row>
+              </Table.Header>
+              <Table.Body>
+                {#each members as member}
+                  <Table.Row>
+                    <Table.Cell class="font-medium">
+                      {member.firstname || ''} {member.lastname || ''}
+                      {#if !member.firstname && !member.lastname}
+                        <span class="text-muted-foreground italic">No name provided</span>
+                      {/if}
+                    </Table.Cell>
+                    <Table.Cell>{member.email}</Table.Cell>
+                    <Table.Cell>{member.username}</Table.Cell>
+                    <Table.Cell class="text-right">
+                      {#if member.username !== auth.user.username}
+                        <Button 
+                          variant="ghost" 
+                          size="icon" 
+                          class="h-8 w-8 text-destructive"
+                          onclick={() => { memberToRemove = member; isConfirmDialogOpen = true; }}
+                        >
+                          <Delete01Icon size={16} />
+                        </Button>
+                      {/if}
+                    </Table.Cell>
+                  </Table.Row>
+                {/each}
+                {#if members.length === 0}
+                  <Table.Row>
+                    <Table.Cell colspan={4} class="text-center text-muted-foreground py-6">
+                      No members found.
+                    </Table.Cell>
+                  </Table.Row>
+                {/if}
+              </Table.Body>
+            </Table.Root>
+          {/if}
+        </Card.Content>
+      </Card.Root>
+
+      <!-- Invite Panel -->
+      <div class="space-y-6">
+        <Card.Root>
+          <Card.Header>
+            <Card.Title class="text-base">Add Member</Card.Title>
+            <Card.Description>Add an existing user to this organization by email.</Card.Description>
+          </Card.Header>
+          <Card.Content>
+            <form class="space-y-4" onsubmit={addMember}>
+              {#if inviteError}
+                <Alert.Root variant="destructive">
+                  <Alert.Description class="text-sm">{inviteError}</Alert.Description>
+                </Alert.Root>
+              {/if}
+              
+              {#if inviteSuccess}
+                <Alert.Root class="border-green-500/50 text-green-600 dark:text-green-400">
+                  <Alert.Description class="text-sm">{inviteSuccess}</Alert.Description>
+                </Alert.Root>
+              {/if}
+
+              <div class="space-y-2">
+                <Label for="email">User Email</Label>
+                <Input 
+                  id="email" 
+                  type="email" 
+                  placeholder="name@example.com" 
+                  bind:value={inviteEmail} 
+                  required
+                />
+              </div>
+
+              <Button type="submit" class="w-full" disabled={isInviting || !inviteEmail}>
+                {#if isInviting}
+                  Adding...
+                {:else}
+                  <PlusSignIcon size={16} class="mr-2" />
+                  Add Member
+                {/if}
+              </Button>
+            </form>
+          </Card.Content>
+        </Card.Root>
+      </div>
+
+    </div>
+  {/if}
+</div>
+
+<ConfirmDialog
+  bind:open={isConfirmDialogOpen}
+  title="Remove Member"
+  description="Are you sure you want to remove {memberToRemove?.email} from the organization?"
+  confirmLabel="Remove"
+  variant="destructive"
+  onConfirm={removeMember}
+  onCancel={() => {
+    memberToRemove = null;
+  }}
+/>


### PR DESCRIPTION
## Description

Resolves #346.

This PR adds the ability for Organization owners to manage their organization's membership directly from the Web UI.

**Key Changes:**
- **Control Plane**: Added a new V1 API under `/api/v1/organizations/{organizationName}/members` with `GET`, `POST`, and `DELETE` methods. Only the organization owner is authorized to use these endpoints.
- **Privacy & Security**: To ensure privacy in a multi-tenant environment, adding a member is done strictly by submitting an exact email address. The backend uses a new `findByEmail` method in `UserRepository` so owners cannot dump or browse the global user list.
- **Web UI**: Added an **Organization Settings** link to the user dropdown menu, which leads to a new `/organization` management page. Owners can list members, invite by email, and securely remove members via a confirmation dialog.
- **Dev Data**: Fixed the `dev-data.sql` script so that organization owners are correctly seeded into the `users_organizations` join table for local testing.