### PR TITLE
style(web-ui): add cursor-pointer to buttons

### DIFF
--- a/web-ui/src/lib/components/ui/button/button.svelte
+++ b/web-ui/src/lib/components/ui/button/button.svelte
@@ -4,7 +4,7 @@
 	import { type VariantProps, tv } from "tailwind-variants";
 
 	export const buttonVariants = tv({
-		base: "focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-lg border border-transparent bg-clip-padding text-sm font-medium focus-visible:ring-3 active:not-aria-[haspopup]:translate-y-px aria-invalid:ring-3 [&_svg:not([class*='size-'])]:size-4 group/button inline-flex shrink-0 items-center justify-center whitespace-nowrap transition-all outline-none select-none disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+		base: "cursor-pointer focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-lg border border-transparent bg-clip-padding text-sm font-medium focus-visible:ring-3 active:not-aria-[haspopup]:translate-y-px aria-invalid:ring-3 [&_svg:not([class*='size-'])]:size-4 group/button inline-flex shrink-0 items-center justify-center whitespace-nowrap transition-all outline-none select-none disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
 		variants: {
 			variant: {
 				default: "bg-primary text-primary-foreground [a]:hover:bg-primary/80",


### PR DESCRIPTION
## Description

This PR adds the `cursor-pointer` class to the base `Button` component in the Web UI. 

Now, hovering over buttons (like Sign In, Add Member, etc.) will also display the familiar hand/pointer icon, making the interface feel a bit more interactive and web-native. Making it consistent across the dashboard.

Screenshot:
<img width="252" height="98" alt="Screenshot from 2026-08-16 00-05-54" src="https://github.com/user-attachments/assets/6ece0379-8f84-4d95-9a91-5f516e5ea967" />

