### PR TITLE
feat: cli `duplicate` command to duplicate configuration plan

### DIFF
--- a/cli/src/commands/config.ts
+++ b/cli/src/commands/config.ts
@@ -359,6 +359,39 @@ configCommand.command('delete <id>')
     Logger.success(`Configuration plan ${id} deleted successfully.`);
   });
 
+/** Duplicate configuration plan by ID */
+configCommand.command('duplicate <id>')
+  .description('Duplicate configuration plan by ID')
+  .requiredOption('-n, --name <newName>', 'Name for the duplicated configuration plan')
+  .option('-o, --output <format>', 'Output format (json, yaml)')
+  .action(async (id, options) => {
+    const response = await fetch(`${ConfigUtil.config.server}/api/v1/configurationPlans/${id}/duplicate?name=${encodeURIComponent(options.name)}`, {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${ConfigUtil.config.token}`
+      }
+    });
+
+    if (!response.ok) {
+      Logger.error('Duplicating configuration plan failed: ' + response.statusText);
+      process.exit(1);
+    }
+
+    const config = await response.json();
+    Logger.success(`Configuration plan '${config.name}' duplicated successfully with ID: ${config.id}`);
+    Context.put('configurationPlan', config);
+
+    if (config.apiKey) {
+      Logger.warn(`The API Key to access future expositions is: ${config.apiKey}`);
+      Logger.warn('Make sure to store it securely, as it will not be shown again.');
+    }
+    
+    if (config.initialAccessToken) {
+      Logger.warn(`The initial access token for OAuth2 clients is: ${config.initialAccessToken}`);
+      Logger.warn('Make sure to store it securely, as it will not be shown again.');
+    }
+  });
+
 
 async function manageInclusionsAndExclusions(options: any) {
   if (options.filter) {

--- a/control-plane/src/main/java/io/reshapr/ctrl/rest/v1/ConfigurationPlanResource.java
+++ b/control-plane/src/main/java/io/reshapr/ctrl/rest/v1/ConfigurationPlanResource.java
@@ -94,6 +94,36 @@ public class ConfigurationPlanResource {
       return Response.status(Response.Status.CREATED).entity(result).build();
    }
 
+   @POST
+   @Authenticated
+   @Path("/{id}/duplicate")
+   @Produces(MediaType.APPLICATION_JSON)
+   public Response duplicateConfigurationPlan(@PathParam("id") String id, @QueryParam("name") String newName) {
+      logger.infof("Duplicating configuration plan with id '%s' to new name '%s'", id, newName);
+
+      if (newName == null || newName.trim().isEmpty()) {
+         return Response.status(Response.Status.BAD_REQUEST).entity("New name must be provided").build();
+      }
+
+      ConfigurationPlan newPlan;
+      try {
+         newPlan = managerService.duplicateConfigurationPlan(id, newName);
+      } catch (IllegalArgumentException e) {
+         logger.errorf("Failed to duplicate configuration plan: %s", e.getMessage());
+         return Response.status(Response.Status.NOT_FOUND).entity(e.getMessage()).build();
+      }
+
+      // On creation, be sure to show the API key if it was requested. It will not be shown again after this.
+      ConfigurationPlanDTO result = v1Mappers.toResource(newPlan);
+      if (newPlan.apiKey != null) {
+         result.apiKey = newPlan.apiKey;
+      }
+      if (newPlan.initialAccessToken != null) {
+         result.initialAccessToken = newPlan.initialAccessToken;
+      }
+      return Response.status(Response.Status.CREATED).entity(result).build();
+   }
+
    @GET
    @Authenticated
    @Path("/{id}")

--- a/control-plane/src/main/java/io/reshapr/ctrl/service/ConfigurationPlanManagerService.java
+++ b/control-plane/src/main/java/io/reshapr/ctrl/service/ConfigurationPlanManagerService.java
@@ -129,6 +129,57 @@ public class ConfigurationPlanManagerService {
    }
 
    /**
+    * Duplicates an existing configuration plan.
+    * @param sourceId the ID of the configuration plan to duplicate
+    * @param newName the name of the new configuration plan
+    * @return the newly created configuration plan
+    * @throws IllegalArgumentException if the source configuration plan is not found
+    */
+   @Transactional
+   public ConfigurationPlan duplicateConfigurationPlan(String sourceId, String newName) {
+      logger.debugf("Duplicating configuration plan with id %s to new name '%s'", sourceId, newName);
+      ConfigurationPlan sourcePlan = configurationPlanRepository.findById(sourceId);
+      if (sourcePlan == null) {
+         logger.errorf("Source configuration plan with id %s not found", sourceId);
+         throw new IllegalArgumentException("Source configuration plan with id " + sourceId + " not found");
+      }
+
+      ConfigurationPlan newPlan = new ConfigurationPlan();
+      newPlan.name = newName;
+      newPlan.description = sourcePlan.description;
+      newPlan.service = sourcePlan.service;
+      newPlan.backendEndpoint = sourcePlan.backendEndpoint;
+      newPlan.backendTimeout = sourcePlan.backendTimeout;
+      newPlan.includedOperations = sourcePlan.includedOperations != null ? new java.util.ArrayList<>(sourcePlan.includedOperations) : null;
+      newPlan.excludedOperations = sourcePlan.excludedOperations != null ? new java.util.ArrayList<>(sourcePlan.excludedOperations) : null;
+      newPlan.includedArtifacts = sourcePlan.includedArtifacts != null ? new java.util.ArrayList<>(sourcePlan.includedArtifacts) : null;
+      newPlan.audit = sourcePlan.audit;
+      newPlan.backendSecret = sourcePlan.backendSecret;
+
+      // Duplicate OAuth2 configuration if present
+      if (sourcePlan.oauth2Configuration != null) {
+         newPlan.oauth2Configuration = new ConfigurationPlan.OAuth2Configuration(
+               sourcePlan.oauth2Configuration.authorizationServers() != null ? new java.util.ArrayList<>(sourcePlan.oauth2Configuration.authorizationServers()) : null,
+               sourcePlan.oauth2Configuration.jwksUri(),
+               sourcePlan.oauth2Configuration.scopes() != null ? new java.util.ArrayList<>(sourcePlan.oauth2Configuration.scopes()) : null
+         );
+      }
+
+      // Automatically generate new API key and/or initial access token if the source had them
+      if (sourcePlan.apiKey != null) {
+         logger.debugf("Generating new API token for duplicated configuration plan %s", newPlan.name);
+         newPlan.apiKey = UUID.randomUUID().toString();
+      }
+      if (sourcePlan.initialAccessToken != null) {
+         logger.debugf("Generating new initial access token for duplicated configuration plan %s", newPlan.name);
+         newPlan.initialAccessToken = UUID.randomUUID().toString();
+      }
+
+      configurationPlanRepository.persistAndFlush(newPlan);
+      return newPlan;
+   }
+
+   /**
     * Updates an existing configuration plan.
     * @param configurationPlan the configuration plan to update with fresh values
     * @param backendSecretId the ID of the backend secret to associate with the configuration plan, can be null

--- a/control-plane/src/main/resources/version.properties
+++ b/control-plane/src/main/resources/version.properties
@@ -1,2 +1,2 @@
 reshapr.version=${project.version}
-reshapr.buildTimestamp=${maven.build.timestamp}
+reshapr.buildTimestamp=${maven.build.timestamp:unknown}

--- a/web-ui/src/lib/api/client.ts
+++ b/web-ui/src/lib/api/client.ts
@@ -121,6 +121,10 @@ export function apiClient() {
       }),
     deleteConfigurationPlan: (id: string) =>
       empty(`/api/v1/configurationPlans/${id}`, { method: 'DELETE' }),
+    duplicateConfigurationPlan: (id: string, name: string) =>
+      json<unknown>(`/api/v1/configurationPlans/${id}/duplicate?name=${encodeURIComponent(name)}`, {
+        method: 'POST'
+      }),
     renewApiKey: (id: string) =>
       json<unknown>(`/api/v1/configurationPlans/${id}/renewApiKey`, { method: 'PUT' }),
 

--- a/web-ui/src/routes/(app)/services/[id]/plans/+page.svelte
+++ b/web-ui/src/routes/(app)/services/[id]/plans/+page.svelte
@@ -212,6 +212,9 @@
 	let duplicateNewName = $state('');
 	let duplicateBusy = $state(false);
 	let duplicateError = $state<string | null>(null);
+	let duplicateSuccess = $state(false);
+	let duplicatedApiKey = $state<string | null>(null);
+	let duplicatedInitialToken = $state<string | null>(null);
 
 	function onDelete(row: PlanRow) {
 		deleteTarget = row;
@@ -222,6 +225,9 @@
 		duplicateTarget = row;
 		duplicateNewName = `${row.name} (Copy)`;
 		duplicateError = null;
+		duplicateSuccess = false;
+		duplicatedApiKey = null;
+		duplicatedInitialToken = null;
 		duplicateOpen = true;
 	}
 
@@ -239,9 +245,16 @@
 		duplicateBusy = true;
 		duplicateError = null;
 		try {
-			await apiClient().duplicateConfigurationPlan(row.id, duplicateNewName.trim());
-			duplicateOpen = false;
+			const res = await apiClient().duplicateConfigurationPlan(row.id, duplicateNewName.trim()) as any;
 			await load();
+			
+			if (res.apiKey || res.initialAccessToken) {
+				duplicatedApiKey = res.apiKey || null;
+				duplicatedInitialToken = res.initialAccessToken || null;
+				duplicateSuccess = true;
+			} else {
+				duplicateOpen = false;
+			}
 		} catch (err) {
 			duplicateError = err instanceof ApiError ? err.message : String(err);
 		} finally {
@@ -409,42 +422,73 @@
 	</p>
 </ConfirmDialog>
 
-<Dialog.Root bind:open={duplicateOpen}>
+<Dialog.Root bind:open={duplicateOpen} onOpenChange={(open) => { if (!open) { duplicateSuccess = false; duplicatedApiKey = null; duplicatedInitialToken = null; } }}>
 	<Dialog.Content>
-		<Dialog.Header>
-			<Dialog.Title>Duplicate configuration plan</Dialog.Title>
-			<Dialog.Description>
-				Create a copy of "{duplicateTarget?.name}". A new API key will be generated if applicable.
-			</Dialog.Description>
-		</Dialog.Header>
-		{#if duplicateError}
-			<ApiErrorAlert message={duplicateError} />
-		{/if}
-		<form onsubmit={confirmDuplicatePlan} class="flex flex-col gap-4 py-2">
-			<div class="flex flex-col gap-2">
-				<Label for="duplicate-name">New plan name</Label>
-				<Input
-					id="duplicate-name"
-					bind:value={duplicateNewName}
-					placeholder="My duplicated plan"
-					disabled={duplicateBusy}
-					required
-				/>
+		{#if duplicateSuccess}
+			<Dialog.Header>
+				<Dialog.Title>Configuration plan duplicated</Dialog.Title>
+				<Dialog.Description>
+					The plan "{duplicateNewName}" has been created successfully.
+				</Dialog.Description>
+			</Dialog.Header>
+			<div class="flex flex-col gap-4 py-2">
+				<p class="text-sm text-muted-foreground">
+					Please copy the generated keys below. You will not be able to see them again!
+				</p>
+				{#if duplicatedApiKey}
+					<div class="flex flex-col gap-1">
+						<Label>API Key</Label>
+						<Input readonly value={duplicatedApiKey} />
+					</div>
+				{/if}
+				{#if duplicatedInitialToken}
+					<div class="flex flex-col gap-1">
+						<Label>Initial Access Token</Label>
+						<Input readonly value={duplicatedInitialToken} />
+					</div>
+				{/if}
 			</div>
 			<Dialog.Footer>
-				<Button
-					type="button"
-					variant="outline"
-					disabled={duplicateBusy}
-					onclick={() => (duplicateOpen = false)}
-				>
-					Cancel
-				</Button>
-				<Button type="submit" disabled={duplicateBusy || !duplicateNewName.trim()}>
-					{duplicateBusy ? 'Duplicating…' : 'Duplicate'}
+				<Button type="button" onclick={() => (duplicateOpen = false)}>
+					Close
 				</Button>
 			</Dialog.Footer>
-		</form>
+		{:else}
+			<Dialog.Header>
+				<Dialog.Title>Duplicate configuration plan</Dialog.Title>
+				<Dialog.Description>
+					Create a copy of "{duplicateTarget?.name}". A new API key will be generated if applicable.
+				</Dialog.Description>
+			</Dialog.Header>
+			{#if duplicateError}
+				<ApiErrorAlert message={duplicateError} />
+			{/if}
+			<form onsubmit={confirmDuplicatePlan} class="flex flex-col gap-4 py-2">
+				<div class="flex flex-col gap-2">
+					<Label for="duplicate-name">New plan name</Label>
+					<Input
+						id="duplicate-name"
+						bind:value={duplicateNewName}
+						placeholder="My duplicated plan"
+						disabled={duplicateBusy}
+						required
+					/>
+				</div>
+				<Dialog.Footer>
+					<Button
+						type="button"
+						variant="outline"
+						disabled={duplicateBusy}
+						onclick={() => (duplicateOpen = false)}
+					>
+						Cancel
+					</Button>
+					<Button type="submit" disabled={duplicateBusy || !duplicateNewName.trim()}>
+						{duplicateBusy ? 'Duplicating…' : 'Duplicate'}
+					</Button>
+				</Dialog.Footer>
+			</form>
+		{/if}
 	</Dialog.Content>
 </Dialog.Root>
 

--- a/web-ui/src/routes/(app)/services/[id]/plans/+page.svelte
+++ b/web-ui/src/routes/(app)/services/[id]/plans/+page.svelte
@@ -31,10 +31,13 @@
 	} from '$lib/components/ui/dropdown-menu/index.js';
 	import { cn } from '$lib/utils.js';
 	import { HugeiconsIcon } from '@hugeicons/svelte';
-	import { MoreVerticalIcon, PencilEdit02Icon, Delete02Icon, RefreshIcon } from '@hugeicons/core-free-icons';
+	import { MoreVerticalIcon, PencilEdit02Icon, Delete02Icon, RefreshIcon, Copy01Icon } from '@hugeicons/core-free-icons';
 	import UserLockIcon from '@lucide/svelte/icons/user-lock';
 	import KeyRoundIcon from '@lucide/svelte/icons/key-round';
 	import MessageSquareLockIcon from '@lucide/svelte/icons/message-square-lock';
+	import * as Dialog from '$lib/components/ui/dialog/index.js';
+	import { Input } from '$lib/components/ui/input/index.js';
+	import { Label } from '$lib/components/ui/label/index.js';
 
 	const ctx = getContext<ServiceContextValue>(SERVICE_CONTEXT_KEY);
 
@@ -204,9 +207,22 @@
 	let deleteTarget = $state<PlanRow | null>(null);
 	let deleteOpen = $state(false);
 
+	let duplicateTarget = $state<PlanRow | null>(null);
+	let duplicateOpen = $state(false);
+	let duplicateNewName = $state('');
+	let duplicateBusy = $state(false);
+	let duplicateError = $state<string | null>(null);
+
 	function onDelete(row: PlanRow) {
 		deleteTarget = row;
 		deleteOpen = true;
+	}
+
+	function onDuplicate(row: PlanRow) {
+		duplicateTarget = row;
+		duplicateNewName = `${row.name} (Copy)`;
+		duplicateError = null;
+		duplicateOpen = true;
 	}
 
 	async function confirmDeletePlan() {
@@ -214,6 +230,23 @@
 		if (!row) return;
 		await apiClient().deleteConfigurationPlan(row.id);
 		await load();
+	}
+
+	async function confirmDuplicatePlan(e: Event) {
+		e.preventDefault();
+		const row = duplicateTarget;
+		if (!row || !duplicateNewName.trim()) return;
+		duplicateBusy = true;
+		duplicateError = null;
+		try {
+			await apiClient().duplicateConfigurationPlan(row.id, duplicateNewName.trim());
+			duplicateOpen = false;
+			await load();
+		} catch (err) {
+			duplicateError = err instanceof ApiError ? err.message : String(err);
+		} finally {
+			duplicateBusy = false;
+		}
 	}
 </script>
 
@@ -329,7 +362,7 @@
 									{/snippet}
 								</DropdownMenuTrigger>
 								<DropdownMenuContent align="end">
-									<DropdownMenuItem>
+									<DropdownMenuItem class="cursor-pointer">
 										{#snippet child({ props })}
 											<a href="/services/{ctx.id}/plans/{p.id}" class="px-4" {...props}>
 												<HugeiconsIcon icon={PencilEdit02Icon} size={16} />
@@ -338,7 +371,14 @@
 										{/snippet}
 									</DropdownMenuItem>
 									<DropdownMenuItem
-										class="text-destructive focus:text-destructive"
+										class="cursor-pointer"
+										onSelect={() => void onDuplicate(p)}
+									>
+										<HugeiconsIcon icon={Copy01Icon} size={16} />
+										Duplicate
+									</DropdownMenuItem>
+									<DropdownMenuItem
+										class="text-destructive focus:text-destructive cursor-pointer"
 										onSelect={() => void onDelete(p)}
 									>
 										<HugeiconsIcon icon={Delete02Icon} size={16} />
@@ -368,3 +408,43 @@
 		will lose access until another plan is configured.
 	</p>
 </ConfirmDialog>
+
+<Dialog.Root bind:open={duplicateOpen}>
+	<Dialog.Content>
+		<Dialog.Header>
+			<Dialog.Title>Duplicate configuration plan</Dialog.Title>
+			<Dialog.Description>
+				Create a copy of "{duplicateTarget?.name}". A new API key will be generated if applicable.
+			</Dialog.Description>
+		</Dialog.Header>
+		{#if duplicateError}
+			<ApiErrorAlert message={duplicateError} />
+		{/if}
+		<form onsubmit={confirmDuplicatePlan} class="flex flex-col gap-4 py-2">
+			<div class="flex flex-col gap-2">
+				<Label for="duplicate-name">New plan name</Label>
+				<Input
+					id="duplicate-name"
+					bind:value={duplicateNewName}
+					placeholder="My duplicated plan"
+					disabled={duplicateBusy}
+					required
+				/>
+			</div>
+			<Dialog.Footer>
+				<Button
+					type="button"
+					variant="outline"
+					disabled={duplicateBusy}
+					onclick={() => (duplicateOpen = false)}
+				>
+					Cancel
+				</Button>
+				<Button type="submit" disabled={duplicateBusy || !duplicateNewName.trim()}>
+					{duplicateBusy ? 'Duplicating…' : 'Duplicate'}
+				</Button>
+			</Dialog.Footer>
+		</form>
+	</Dialog.Content>
+</Dialog.Root>
+


### PR DESCRIPTION
## Description

This PR fulfills the remaining requirement for Issue #263 (as discussed in https://github.com/reshaprio/reshapr/pull/370#issuecomment-5397543174) by adding the `duplicate` command to the CLI for configuration plans. 

The new command supports duplicating an existing configuration plan and maintains parity with the Web UI by safely exposing the newly generated API Key or OAuth2 Initial Access Token immediately after duplication so the user can securely store it.

## Validation

```console
vaishnavsk@vaishnav88:~/reshapr/cli$ reshapr service list
ID             NAME           VERSION  TYPE  AGE
0RDJ3MYMXQR8S  Dummy Service  1.0.0    REST  25s

vaishnavsk@vaishnav88:~/reshapr/cli$ reshapr config create "Base Plan" -s 0RDJ3MYMXQR8S --be http://localhost:8080 --apiKey
✅ Configuration plan 'Base Plan' created successfully with ID: 0RDJ3ZW9HQRFS
⚠️  The API Key to access future expositions is: a811a912-f877-4514-9e52-a2deb93c4dca
⚠️  Make sure to store it securely, as it will not be shown again.

vaishnavsk@vaishnav88:~/reshapr/cli$ reshapr config list
ID             NAME       SERVICE        BACKEND                API_KEY  OAUTH2_CONFIG  AUDIT
0RDJ3ZW9HQRFS  Base Plan  0RDJ3MYMXQR8S  http://localhost:8080  Yes      No             No

vaishnavsk@vaishnav88:~/reshapr/cli$ reshapr config duplicate 0RDJ3ZW9HQRFS -n "Cloned Plan"
✅ Configuration plan 'Cloned Plan' duplicated successfully with ID: 0RDJ481S1QRFM
⚠️  The API Key to access future expositions is: 56483c60-6e28-4699-81eb-6a50fb6ae08e
⚠️  Make sure to store it securely, as it will not be shown again.
```