### PR TITLE
Feat: Add MCP client caching configuration to Configuration Plans

### DIFF
--- a/api/src/main/proto/eds-v1.proto
+++ b/api/src/main/proto/eds-v1.proto
@@ -45,11 +45,11 @@ message Configuration {
   optional Secret backendSecret = 8;
   optional int64 backendTimeout = 9;  // For backend endpoint Timeout
   bool audit = 10; // Whether audit logging is enabled for this configuration
-  optional CachingConfiguration cachingConfiguration = 11; // Client-side caching directives (MCP >= 2026-07-28)
+  optional CachePolicy cachePolicy = 11; // Client-side caching directives (MCP >= 2026-07-28)
 }
 
-// CachingConfiguration holds the MCP client-cache hints returned in list/read results.
-message CachingConfiguration {
+// CachePolicy holds the MCP client-cache hints returned in list/read results.
+message CachePolicy {
   optional int64 ttlMs = 1;       // Time-to-live in milliseconds
   optional string cacheScope = 2; // Cache scope (e.g. "public" or "private")
 }

--- a/api/src/main/proto/eds-v1.proto
+++ b/api/src/main/proto/eds-v1.proto
@@ -45,6 +45,13 @@ message Configuration {
   optional Secret backendSecret = 8;
   optional int64 backendTimeout = 9;  // For backend endpoint Timeout
   bool audit = 10; // Whether audit logging is enabled for this configuration
+  optional CachingConfiguration cachingConfiguration = 11; // Client-side caching directives (MCP >= 2026-07-28)
+}
+
+// CachingConfiguration holds the MCP client-cache hints returned in list/read results.
+message CachingConfiguration {
+  optional int64 ttlMs = 1;       // Time-to-live in milliseconds
+  optional string cacheScope = 2; // Cache scope (e.g. "public" or "private")
 }
 
 message OAuth2Configuration {

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -489,9 +489,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -509,9 +506,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -529,9 +523,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -549,9 +540,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -569,9 +557,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -589,9 +574,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1633,9 +1615,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1657,9 +1636,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1681,9 +1657,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1705,9 +1678,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/cli/src/commands/config.ts
+++ b/cli/src/commands/config.ts
@@ -167,7 +167,7 @@ configCommand.command('create <name>')
         includedArtifacts: options.includedArtifacts ? getArrayOfStrings(options.includedArtifacts, 'includedArtifacts') : undefined,
         apiKey: (options.apiKey ? 'generate-me' : undefined),
         initialAccessToken: (options.internalOAuth2 ? 'generate-me' : undefined),
-        cachingConfiguration: {
+        cachePolicy: {
           ttlMs: parseInt(options.cacheTtl, 10),
           cacheScope: options.cacheScope
         },
@@ -246,7 +246,7 @@ configCommand.command('create-oauth <name>')
         excludedOperations: options.excludedOps || undefined,
         includedArtifacts: options.includedArtifacts ? getArrayOfStrings(options.includedArtifacts, 'includedArtifacts') : undefined,
         oauth2Configuration: options.oauth2Configuration,
-        cachingConfiguration: {
+        cachePolicy: {
           ttlMs: parseInt(options.cacheTtl, 10),
           cacheScope: options.cacheScope
         },

--- a/cli/src/commands/config.ts
+++ b/cli/src/commands/config.ts
@@ -138,6 +138,8 @@ configCommand.command('create <name>')
   .option('--ia, --includedArtifacts [<artifact1>, <artifact2>]', 'Include only these attached artifact names in the plan (JSON array). Empty/absent means all the attached artifacts of the service apply.')
   .option('--apiKey', 'Generate an API key for this configuration plan to secure the MCP endpoint')
   .option('--audit', 'Enable audit logging for this configuration plan')
+  .option('--ct, --cacheTtl <cacheTtlMs>', 'Cache TTL in milliseconds', '30000')
+  .option('--cs, --cacheScope <cacheScope>', 'Cache scope (e.g. public, private)', 'public')
   .option('-o, --output <format>', 'Output format (json, yaml)')
   .action(async (name, options) => {
     if (!options.serviceId) {
@@ -165,6 +167,10 @@ configCommand.command('create <name>')
         includedArtifacts: options.includedArtifacts ? getArrayOfStrings(options.includedArtifacts, 'includedArtifacts') : undefined,
         apiKey: (options.apiKey ? 'generate-me' : undefined),
         initialAccessToken: (options.internalOAuth2 ? 'generate-me' : undefined),
+        cachingConfiguration: {
+          ttlMs: parseInt(options.cacheTtl, 10),
+          cacheScope: options.cacheScope
+        },
         audit: options.audit || false
       })
     });
@@ -206,6 +212,8 @@ configCommand.command('create-oauth <name>')
   .requiredOption('--oju, --oauth2jwksUri <jwksUri>', 'The JWKS URI to validate OAuth2 tokens')
   .option('--osc, --oauth2Scopes [<scope1>, <scope2>]', 'A list of OAuth2 scopes to enforce presence in the access token')
   .option('--audit', 'Enable audit logging for this configuration plan')
+  .option('--ct, --cacheTtl <cacheTtlMs>', 'Cache TTL in milliseconds', '30000')
+  .option('--cs, --cacheScope <cacheScope>', 'Cache scope (e.g. public, private)', 'public')
   .option('-o, --output <format>', 'Output format (json, yaml)')
   .action(async (name, options) => {
     if (!options.serviceId) {
@@ -238,6 +246,10 @@ configCommand.command('create-oauth <name>')
         excludedOperations: options.excludedOps || undefined,
         includedArtifacts: options.includedArtifacts ? getArrayOfStrings(options.includedArtifacts, 'includedArtifacts') : undefined,
         oauth2Configuration: options.oauth2Configuration,
+        cachingConfiguration: {
+          ttlMs: parseInt(options.cacheTtl, 10),
+          cacheScope: options.cacheScope
+        },
         audit: options.audit || false
       })
     });

--- a/cli/src/version.ts
+++ b/cli/src/version.ts
@@ -1,1 +1,1 @@
-export const CLI_VERSION = "0.2.2";
+export const CLI_VERSION = "0.2.2-SNAPSHOT";

--- a/control-plane/src/main/java/io/reshapr/ctrl/model/ConfigurationPlan.java
+++ b/control-plane/src/main/java/io/reshapr/ctrl/model/ConfigurationPlan.java
@@ -95,6 +95,10 @@ public class ConfigurationPlan extends TenantAwareEntity {
    @Column(name = "audit")
    public boolean audit;
 
+   @Type(JsonType.class)
+   @Column(columnDefinition = "JSONB", name = "caching_configuration")
+   public CachingConfiguration cachingConfiguration;
+
    @ManyToOne(fetch = EAGER)
    @JoinColumn(name = "backend_secret_id")
    public Secret backendSecret;
@@ -104,5 +108,38 @@ public class ConfigurationPlan extends TenantAwareEntity {
          String jwksUri,
          List<String> scopes
    ) {
+   }
+
+   /**
+    * Caching directives passed to the MCP client as {@code ttlMs} and {@code cacheScope}
+    * on list/read results (MCP protocol >= 2026-07-28).
+    *
+    * @param ttlMs       Time-to-live in milliseconds for client-side caching. Defaults to 30 000 ms.
+    * @param cacheScope  Cache scope to advertise to the client (e.g. {@code "public"} or
+    *                    {@code "private"}). Defaults to {@code "public"}.
+    */
+   public record CachingConfiguration(
+         Long ttlMs,
+         String cacheScope
+   ) {
+      /** Default TTL in milliseconds (30 seconds). */
+      public static final long DEFAULT_TTL_MS = 30_000L;
+      /** Default cache scope advertised to MCP clients. */
+      public static final String DEFAULT_CACHE_SCOPE = "public";
+
+      /** Returns a {@link CachingConfiguration} with the default values. */
+      public static CachingConfiguration defaults() {
+         return new CachingConfiguration(DEFAULT_TTL_MS, DEFAULT_CACHE_SCOPE);
+      }
+
+      /** Returns {@code ttlMs} if set, otherwise {@link #DEFAULT_TTL_MS}. */
+      public long effectiveTtlMs() {
+         return ttlMs != null ? ttlMs : DEFAULT_TTL_MS;
+      }
+
+      /** Returns {@code cacheScope} if set, otherwise {@link #DEFAULT_CACHE_SCOPE}. */
+      public String effectiveCacheScope() {
+         return cacheScope != null ? cacheScope : DEFAULT_CACHE_SCOPE;
+      }
    }
 }

--- a/control-plane/src/main/java/io/reshapr/ctrl/model/ConfigurationPlan.java
+++ b/control-plane/src/main/java/io/reshapr/ctrl/model/ConfigurationPlan.java
@@ -96,8 +96,8 @@ public class ConfigurationPlan extends TenantAwareEntity {
    public boolean audit;
 
    @Type(JsonType.class)
-   @Column(columnDefinition = "JSONB", name = "caching_configuration")
-   public CachingConfiguration cachingConfiguration;
+   @Column(columnDefinition = "JSONB", name = "cache_policy")
+   public CachePolicy cachePolicy;
 
    @ManyToOne(fetch = EAGER)
    @JoinColumn(name = "backend_secret_id")
@@ -118,7 +118,7 @@ public class ConfigurationPlan extends TenantAwareEntity {
     * @param cacheScope  Cache scope to advertise to the client (e.g. {@code "public"} or
     *                    {@code "private"}). Defaults to {@code "public"}.
     */
-   public record CachingConfiguration(
+   public record CachePolicy(
          Long ttlMs,
          String cacheScope
    ) {
@@ -127,9 +127,9 @@ public class ConfigurationPlan extends TenantAwareEntity {
       /** Default cache scope advertised to MCP clients. */
       public static final String DEFAULT_CACHE_SCOPE = "public";
 
-      /** Returns a {@link CachingConfiguration} with the default values. */
-      public static CachingConfiguration defaults() {
-         return new CachingConfiguration(DEFAULT_TTL_MS, DEFAULT_CACHE_SCOPE);
+      /** Returns a {@link CachePolicy} with the default values. */
+      public static CachePolicy defaults() {
+         return new CachePolicy(DEFAULT_TTL_MS, DEFAULT_CACHE_SCOPE);
       }
 
       /** Returns {@code ttlMs} if set, otherwise {@link #DEFAULT_TTL_MS}. */

--- a/control-plane/src/main/java/io/reshapr/ctrl/rest/v1/ConfigurationPlanDTO.java
+++ b/control-plane/src/main/java/io/reshapr/ctrl/rest/v1/ConfigurationPlanDTO.java
@@ -50,7 +50,7 @@ public class ConfigurationPlanDTO {
     // Indicates whether to use the internal identity provider for OAuth2 authentication.
     protected String initialAccessToken;
     protected boolean audit;
-   protected CachingConfigurationDTO cachingConfiguration;
+   protected CachePolicyDTO cachePolicy;
 
    public String getId() {
       return id;
@@ -172,12 +172,12 @@ public class ConfigurationPlanDTO {
        this.audit = audit;
     }
 
-   public CachingConfigurationDTO getCachingConfiguration() {
-      return cachingConfiguration;
+   public CachePolicyDTO getCachePolicy() {
+      return cachePolicy;
    }
 
-   public void setCachingConfiguration(CachingConfigurationDTO cachingConfiguration) {
-      this.cachingConfiguration = cachingConfiguration;
+   public void setCachePolicy(CachePolicyDTO cachePolicy) {
+      this.cachePolicy = cachePolicy;
    }
 
    /**
@@ -185,7 +185,7 @@ public class ConfigurationPlanDTO {
     * Both fields are optional; when absent the proxy falls back to its built-in defaults.
     */
    @RegisterForReflection
-   public static class CachingConfigurationDTO {
+   public static class CachePolicyDTO {
       /** Time-to-live in milliseconds for client-side MCP caching. */
       private Long ttlMs;
       /** Cache scope to advertise (e.g. "public" or "private"). */

--- a/control-plane/src/main/java/io/reshapr/ctrl/rest/v1/ConfigurationPlanDTO.java
+++ b/control-plane/src/main/java/io/reshapr/ctrl/rest/v1/ConfigurationPlanDTO.java
@@ -50,6 +50,7 @@ public class ConfigurationPlanDTO {
     // Indicates whether to use the internal identity provider for OAuth2 authentication.
     protected String initialAccessToken;
     protected boolean audit;
+   protected CachingConfigurationDTO cachingConfiguration;
 
    public String getId() {
       return id;
@@ -170,4 +171,30 @@ public class ConfigurationPlanDTO {
     public void setAudit(boolean audit) {
        this.audit = audit;
     }
+
+   public CachingConfigurationDTO getCachingConfiguration() {
+      return cachingConfiguration;
+   }
+
+   public void setCachingConfiguration(CachingConfigurationDTO cachingConfiguration) {
+      this.cachingConfiguration = cachingConfiguration;
+   }
+
+   /**
+    * DTO for the caching configuration of a {@code ConfigurationPlan}.
+    * Both fields are optional; when absent the proxy falls back to its built-in defaults.
+    */
+   @RegisterForReflection
+   public static class CachingConfigurationDTO {
+      /** Time-to-live in milliseconds for client-side MCP caching. */
+      private Long ttlMs;
+      /** Cache scope to advertise (e.g. "public" or "private"). */
+      private String cacheScope;
+
+      public Long getTtlMs() { return ttlMs; }
+      public void setTtlMs(Long ttlMs) { this.ttlMs = ttlMs; }
+
+      public String getCacheScope() { return cacheScope; }
+      public void setCacheScope(String cacheScope) { this.cacheScope = cacheScope; }
+   }
 }

--- a/control-plane/src/main/java/io/reshapr/ctrl/service/ExpositionDiscoveryServiceHandler.java
+++ b/control-plane/src/main/java/io/reshapr/ctrl/service/ExpositionDiscoveryServiceHandler.java
@@ -430,16 +430,16 @@ public class ExpositionDiscoveryServiceHandler extends ExpositionDiscoveryServic
          builder.setBackendSecret(grpcSecretFromModel(configuration.backendSecret));
       }
       builder.setAudit(configuration.audit);
-      if (configuration.cachingConfiguration != null) {
-         io.reshapr.discovery.exposition.v1.CachingConfiguration.Builder cachingBuilder =
-               io.reshapr.discovery.exposition.v1.CachingConfiguration.newBuilder();
-         if (configuration.cachingConfiguration.ttlMs() != null) {
-            cachingBuilder.setTtlMs(configuration.cachingConfiguration.ttlMs());
+      if (configuration.cachePolicy != null) {
+         io.reshapr.discovery.exposition.v1.CachePolicy.Builder cachingBuilder =
+               io.reshapr.discovery.exposition.v1.CachePolicy.newBuilder();
+         if (configuration.cachePolicy.ttlMs() != null) {
+            cachingBuilder.setTtlMs(configuration.cachePolicy.ttlMs());
          }
-         if (configuration.cachingConfiguration.cacheScope() != null) {
-            cachingBuilder.setCacheScope(configuration.cachingConfiguration.cacheScope());
+         if (configuration.cachePolicy.cacheScope() != null) {
+            cachingBuilder.setCacheScope(configuration.cachePolicy.cacheScope());
          }
-         builder.setCachingConfiguration(cachingBuilder.build());
+         builder.setCachePolicy(cachingBuilder.build());
       }
       return builder.build();
    }

--- a/control-plane/src/main/java/io/reshapr/ctrl/service/ExpositionDiscoveryServiceHandler.java
+++ b/control-plane/src/main/java/io/reshapr/ctrl/service/ExpositionDiscoveryServiceHandler.java
@@ -430,6 +430,17 @@ public class ExpositionDiscoveryServiceHandler extends ExpositionDiscoveryServic
          builder.setBackendSecret(grpcSecretFromModel(configuration.backendSecret));
       }
       builder.setAudit(configuration.audit);
+      if (configuration.cachingConfiguration != null) {
+         io.reshapr.discovery.exposition.v1.CachingConfiguration.Builder cachingBuilder =
+               io.reshapr.discovery.exposition.v1.CachingConfiguration.newBuilder();
+         if (configuration.cachingConfiguration.ttlMs() != null) {
+            cachingBuilder.setTtlMs(configuration.cachingConfiguration.ttlMs());
+         }
+         if (configuration.cachingConfiguration.cacheScope() != null) {
+            cachingBuilder.setCacheScope(configuration.cachingConfiguration.cacheScope());
+         }
+         builder.setCachingConfiguration(cachingBuilder.build());
+      }
       return builder.build();
    }
 

--- a/control-plane/src/main/resources/application.properties
+++ b/control-plane/src/main/resources/application.properties
@@ -96,3 +96,4 @@ reshapr.ctrl.api.key=${RESHAPR_CTRL_API_KEY:CzBuQ9B0i8qrUQe6WLiDLqR3gv4iCbxvjTJQ
 # Encryption key used to encrypt sensitive data in the database.
 reshapr.encryption.key=${RESHAPR_ENCRYPTION_KEY:my-super-secret-key-32-char-long}
 
+%test.maven.build.timestamp=test

--- a/control-plane/src/main/resources/db/migration/V1.5.0__add_cache_policy.sql
+++ b/control-plane/src/main/resources/db/migration/V1.5.0__add_cache_policy.sql
@@ -4,4 +4,4 @@
 -- NULL means "use proxy defaults" (30 000 ms, "public").
 
 ALTER TABLE configuration_plans
-    ADD COLUMN IF NOT EXISTS caching_configuration JSONB;
+    ADD COLUMN IF NOT EXISTS cache_policy JSONB;

--- a/control-plane/src/main/resources/db/migration/V1.5.0__add_caching_configuration.sql
+++ b/control-plane/src/main/resources/db/migration/V1.5.0__add_caching_configuration.sql
@@ -1,0 +1,7 @@
+-- Flyway migration V1.5.0
+-- Issue #323: Add per-ConfigurationPlan caching configuration
+-- Stores MCP client-cache hints (ttlMs, cacheScope) as a JSONB column.
+-- NULL means "use proxy defaults" (30 000 ms, "public").
+
+ALTER TABLE configuration_plans
+    ADD COLUMN IF NOT EXISTS caching_configuration JSONB;

--- a/proxy/src/main/java/io/reshapr/proxy/mcp/McpController.java
+++ b/proxy/src/main/java/io/reshapr/proxy/mcp/McpController.java
@@ -594,13 +594,18 @@ public class McpController {
             "io.modelcontextprotocol/serverInfo", serverInfo
       );
 
+      ConfigurationEntry configuration = exposition.configuration();
+      ConfigurationEntry.CachingConfigurationEntry caching = configuration.cachingConfiguration();
+      long ttlMs = caching != null ? caching.effectiveTtlMs() : ConfigurationEntry.CachingConfigurationEntry.DEFAULT_TTL_MS;
+      String cacheScope = caching != null ? caching.effectiveCacheScope() : ConfigurationEntry.CachingConfigurationEntry.DEFAULT_CACHE_SCOPE;
+
       McpSchema.DiscoverResult discoverResult = new McpSchema.DiscoverResult(
             McpSchema.SUPPORTED_PROTOCOL_VERSIONS,
             serverCapabilities,
             serverInfo,
             meta,
-            60_000L,
-            "public");
+            ttlMs,
+            cacheScope);
 
       return toMcpHandlerResult(request, discoverResult);
    }
@@ -655,10 +660,12 @@ public class McpController {
       // Delegate the version-specific result shaping to the negotiated protocol dialect. The modern
       // client-cache hints are always provided here; they are honored only under a modern dialect and
       // silently dropped in legacy mode.
-      // TODO: source ttlMs / cacheScope from the exposition configuration instead of these placeholders.
+      // Source ttlMs / cacheScope from the exposition's cachingConfiguration, falling back to defaults.
+      ConfigurationEntry configuration = exposition.configuration();
+      ConfigurationEntry.CachingConfigurationEntry caching = configuration.cachingConfiguration();
       McpSchema.ListPromptsResult result = dialect.newListPromptsResult(builder.listPrompts())
-            .ttlMs(60_000L)
-            .cacheScope("public")
+            .ttlMs(caching != null ? caching.effectiveTtlMs() : ConfigurationEntry.CachingConfigurationEntry.DEFAULT_TTL_MS)
+            .cacheScope(caching != null ? caching.effectiveCacheScope() : ConfigurationEntry.CachingConfigurationEntry.DEFAULT_CACHE_SCOPE)
             .build();
 
       return toMcpHandlerResult(request, result);
@@ -687,10 +694,12 @@ public class McpController {
       // Delegate the version-specific result shaping to the negotiated protocol dialect. The modern
       // client-cache hints are always provided here; they are honored only under a modern dialect and
       // silently dropped in legacy mode.
-      // TODO: source ttlMs / cacheScope from the exposition configuration instead of these placeholders.
+      // Source ttlMs / cacheScope from the exposition's cachingConfiguration, falling back to defaults.
+      ConfigurationEntry configuration = exposition.configuration();
+      ConfigurationEntry.CachingConfigurationEntry caching = configuration.cachingConfiguration();
       McpSchema.ListResourcesResult result = dialect.newListResourcesResult(builder.listResources())
-            .ttlMs(60_000L)
-            .cacheScope("public")
+            .ttlMs(caching != null ? caching.effectiveTtlMs() : ConfigurationEntry.CachingConfigurationEntry.DEFAULT_TTL_MS)
+            .cacheScope(caching != null ? caching.effectiveCacheScope() : ConfigurationEntry.CachingConfigurationEntry.DEFAULT_CACHE_SCOPE)
             .build();
 
       return toMcpHandlerResult(request, result);
@@ -705,10 +714,12 @@ public class McpController {
       // Delegate the version-specific result shaping to the negotiated protocol dialect. The modern
       // client-cache hints are always provided here; they are honored only under a modern dialect and
       // silently dropped in legacy mode.
-      // TODO: source ttlMs / cacheScope from the exposition configuration instead of these placeholders.
+      // Source ttlMs / cacheScope from the exposition's cachingConfiguration, falling back to defaults.
+      ConfigurationEntry configEntry = exposition.configuration();
+      ConfigurationEntry.CachingConfigurationEntry cachingEntry = configEntry.cachingConfiguration();
       McpSchema.ListResourceTemplatesResult result = dialect.newListResourceTemplatesResult(builder.listResourceTemplates())
-            .ttlMs(60_000L)
-            .cacheScope("public")
+            .ttlMs(cachingEntry != null ? cachingEntry.effectiveTtlMs() : ConfigurationEntry.CachingConfigurationEntry.DEFAULT_TTL_MS)
+            .cacheScope(cachingEntry != null ? cachingEntry.effectiveCacheScope() : ConfigurationEntry.CachingConfigurationEntry.DEFAULT_CACHE_SCOPE)
             .build();
 
       return toMcpHandlerResult(request, result);
@@ -739,10 +750,11 @@ public class McpController {
       // Delegate the version-specific result shaping to the negotiated protocol dialect. The modern
       // client-cache hints are always provided here; they are honored only under a modern dialect and
       // silently dropped in legacy mode.
-      // TODO: source ttlMs / cacheScope from the exposition configuration instead of these placeholders.
+      // Source ttlMs / cacheScope from the exposition's cachingConfiguration, falling back to defaults.
+      ConfigurationEntry.CachingConfigurationEntry cachingEntry = configuration.cachingConfiguration();
       McpSchema.ReadResourceResult result = dialect.newReadResourceResult(contents)
-            .ttlMs(60_000L)
-            .cacheScope("public")
+            .ttlMs(cachingEntry != null ? cachingEntry.effectiveTtlMs() : ConfigurationEntry.CachingConfigurationEntry.DEFAULT_TTL_MS)
+            .cacheScope(cachingEntry != null ? cachingEntry.effectiveCacheScope() : ConfigurationEntry.CachingConfigurationEntry.DEFAULT_CACHE_SCOPE)
             .build();
 
       return toMcpHandlerResult(request, result);
@@ -782,10 +794,11 @@ public class McpController {
       // Delegate the version-specific result shaping to the negotiated protocol dialect. The modern
       // client-cache hints are always provided here; they are honored only under a modern dialect and
       // silently dropped in legacy mode.
-      // TODO: source ttlMs / cacheScope from the exposition configuration instead of these placeholders.
+      // Source ttlMs / cacheScope from the exposition's cachingConfiguration, falling back to defaults.
+      ConfigurationEntry.CachingConfigurationEntry cachingEntry = configuration.cachingConfiguration();
       McpSchema.ListToolsResult result = dialect.newListToolsResult(tools)
-            .ttlMs(60_000L)
-            .cacheScope("public")
+            .ttlMs(cachingEntry != null ? cachingEntry.effectiveTtlMs() : ConfigurationEntry.CachingConfigurationEntry.DEFAULT_TTL_MS)
+            .cacheScope(cachingEntry != null ? cachingEntry.effectiveCacheScope() : ConfigurationEntry.CachingConfigurationEntry.DEFAULT_CACHE_SCOPE)
             .build();
 
       return toMcpHandlerResult(request, result);

--- a/proxy/src/main/java/io/reshapr/proxy/mcp/McpController.java
+++ b/proxy/src/main/java/io/reshapr/proxy/mcp/McpController.java
@@ -595,9 +595,9 @@ public class McpController {
       );
 
       ConfigurationEntry configuration = exposition.configuration();
-      ConfigurationEntry.CachingConfigurationEntry caching = configuration.cachingConfiguration();
-      long ttlMs = caching != null ? caching.effectiveTtlMs() : ConfigurationEntry.CachingConfigurationEntry.DEFAULT_TTL_MS;
-      String cacheScope = caching != null ? caching.effectiveCacheScope() : ConfigurationEntry.CachingConfigurationEntry.DEFAULT_CACHE_SCOPE;
+      ConfigurationEntry.CachePolicyEntry caching = configuration.cachePolicy();
+      long ttlMs = caching != null ? caching.effectiveTtlMs() : ConfigurationEntry.CachePolicyEntry.DEFAULT_TTL_MS;
+      String cacheScope = caching != null ? caching.effectiveCacheScope() : ConfigurationEntry.CachePolicyEntry.DEFAULT_CACHE_SCOPE;
 
       McpSchema.DiscoverResult discoverResult = new McpSchema.DiscoverResult(
             McpSchema.SUPPORTED_PROTOCOL_VERSIONS,
@@ -660,12 +660,12 @@ public class McpController {
       // Delegate the version-specific result shaping to the negotiated protocol dialect. The modern
       // client-cache hints are always provided here; they are honored only under a modern dialect and
       // silently dropped in legacy mode.
-      // Source ttlMs / cacheScope from the exposition's cachingConfiguration, falling back to defaults.
+      // Source ttlMs / cacheScope from the exposition's cachePolicy, falling back to defaults.
       ConfigurationEntry configuration = exposition.configuration();
-      ConfigurationEntry.CachingConfigurationEntry caching = configuration.cachingConfiguration();
+      ConfigurationEntry.CachePolicyEntry caching = configuration.cachePolicy();
       McpSchema.ListPromptsResult result = dialect.newListPromptsResult(builder.listPrompts())
-            .ttlMs(caching != null ? caching.effectiveTtlMs() : ConfigurationEntry.CachingConfigurationEntry.DEFAULT_TTL_MS)
-            .cacheScope(caching != null ? caching.effectiveCacheScope() : ConfigurationEntry.CachingConfigurationEntry.DEFAULT_CACHE_SCOPE)
+            .ttlMs(caching != null ? caching.effectiveTtlMs() : ConfigurationEntry.CachePolicyEntry.DEFAULT_TTL_MS)
+            .cacheScope(caching != null ? caching.effectiveCacheScope() : ConfigurationEntry.CachePolicyEntry.DEFAULT_CACHE_SCOPE)
             .build();
 
       return toMcpHandlerResult(request, result);
@@ -694,12 +694,12 @@ public class McpController {
       // Delegate the version-specific result shaping to the negotiated protocol dialect. The modern
       // client-cache hints are always provided here; they are honored only under a modern dialect and
       // silently dropped in legacy mode.
-      // Source ttlMs / cacheScope from the exposition's cachingConfiguration, falling back to defaults.
+      // Source ttlMs / cacheScope from the exposition's cachePolicy, falling back to defaults.
       ConfigurationEntry configuration = exposition.configuration();
-      ConfigurationEntry.CachingConfigurationEntry caching = configuration.cachingConfiguration();
+      ConfigurationEntry.CachePolicyEntry caching = configuration.cachePolicy();
       McpSchema.ListResourcesResult result = dialect.newListResourcesResult(builder.listResources())
-            .ttlMs(caching != null ? caching.effectiveTtlMs() : ConfigurationEntry.CachingConfigurationEntry.DEFAULT_TTL_MS)
-            .cacheScope(caching != null ? caching.effectiveCacheScope() : ConfigurationEntry.CachingConfigurationEntry.DEFAULT_CACHE_SCOPE)
+            .ttlMs(caching != null ? caching.effectiveTtlMs() : ConfigurationEntry.CachePolicyEntry.DEFAULT_TTL_MS)
+            .cacheScope(caching != null ? caching.effectiveCacheScope() : ConfigurationEntry.CachePolicyEntry.DEFAULT_CACHE_SCOPE)
             .build();
 
       return toMcpHandlerResult(request, result);
@@ -714,12 +714,12 @@ public class McpController {
       // Delegate the version-specific result shaping to the negotiated protocol dialect. The modern
       // client-cache hints are always provided here; they are honored only under a modern dialect and
       // silently dropped in legacy mode.
-      // Source ttlMs / cacheScope from the exposition's cachingConfiguration, falling back to defaults.
+      // Source ttlMs / cacheScope from the exposition's cachePolicy, falling back to defaults.
       ConfigurationEntry configEntry = exposition.configuration();
-      ConfigurationEntry.CachingConfigurationEntry cachingEntry = configEntry.cachingConfiguration();
+      ConfigurationEntry.CachePolicyEntry cachingEntry = configEntry.cachePolicy();
       McpSchema.ListResourceTemplatesResult result = dialect.newListResourceTemplatesResult(builder.listResourceTemplates())
-            .ttlMs(cachingEntry != null ? cachingEntry.effectiveTtlMs() : ConfigurationEntry.CachingConfigurationEntry.DEFAULT_TTL_MS)
-            .cacheScope(cachingEntry != null ? cachingEntry.effectiveCacheScope() : ConfigurationEntry.CachingConfigurationEntry.DEFAULT_CACHE_SCOPE)
+            .ttlMs(cachingEntry != null ? cachingEntry.effectiveTtlMs() : ConfigurationEntry.CachePolicyEntry.DEFAULT_TTL_MS)
+            .cacheScope(cachingEntry != null ? cachingEntry.effectiveCacheScope() : ConfigurationEntry.CachePolicyEntry.DEFAULT_CACHE_SCOPE)
             .build();
 
       return toMcpHandlerResult(request, result);
@@ -750,11 +750,11 @@ public class McpController {
       // Delegate the version-specific result shaping to the negotiated protocol dialect. The modern
       // client-cache hints are always provided here; they are honored only under a modern dialect and
       // silently dropped in legacy mode.
-      // Source ttlMs / cacheScope from the exposition's cachingConfiguration, falling back to defaults.
-      ConfigurationEntry.CachingConfigurationEntry cachingEntry = configuration.cachingConfiguration();
+      // Source ttlMs / cacheScope from the exposition's cachePolicy, falling back to defaults.
+      ConfigurationEntry.CachePolicyEntry cachingEntry = configuration.cachePolicy();
       McpSchema.ReadResourceResult result = dialect.newReadResourceResult(contents)
-            .ttlMs(cachingEntry != null ? cachingEntry.effectiveTtlMs() : ConfigurationEntry.CachingConfigurationEntry.DEFAULT_TTL_MS)
-            .cacheScope(cachingEntry != null ? cachingEntry.effectiveCacheScope() : ConfigurationEntry.CachingConfigurationEntry.DEFAULT_CACHE_SCOPE)
+            .ttlMs(cachingEntry != null ? cachingEntry.effectiveTtlMs() : ConfigurationEntry.CachePolicyEntry.DEFAULT_TTL_MS)
+            .cacheScope(cachingEntry != null ? cachingEntry.effectiveCacheScope() : ConfigurationEntry.CachePolicyEntry.DEFAULT_CACHE_SCOPE)
             .build();
 
       return toMcpHandlerResult(request, result);
@@ -794,11 +794,11 @@ public class McpController {
       // Delegate the version-specific result shaping to the negotiated protocol dialect. The modern
       // client-cache hints are always provided here; they are honored only under a modern dialect and
       // silently dropped in legacy mode.
-      // Source ttlMs / cacheScope from the exposition's cachingConfiguration, falling back to defaults.
-      ConfigurationEntry.CachingConfigurationEntry cachingEntry = configuration.cachingConfiguration();
+      // Source ttlMs / cacheScope from the exposition's cachePolicy, falling back to defaults.
+      ConfigurationEntry.CachePolicyEntry cachingEntry = configuration.cachePolicy();
       McpSchema.ListToolsResult result = dialect.newListToolsResult(tools)
-            .ttlMs(cachingEntry != null ? cachingEntry.effectiveTtlMs() : ConfigurationEntry.CachingConfigurationEntry.DEFAULT_TTL_MS)
-            .cacheScope(cachingEntry != null ? cachingEntry.effectiveCacheScope() : ConfigurationEntry.CachingConfigurationEntry.DEFAULT_CACHE_SCOPE)
+            .ttlMs(cachingEntry != null ? cachingEntry.effectiveTtlMs() : ConfigurationEntry.CachePolicyEntry.DEFAULT_TTL_MS)
+            .cacheScope(cachingEntry != null ? cachingEntry.effectiveCacheScope() : ConfigurationEntry.CachePolicyEntry.DEFAULT_CACHE_SCOPE)
             .build();
 
       return toMcpHandlerResult(request, result);

--- a/proxy/src/main/java/io/reshapr/proxy/registry/ConfigurationEntry.java
+++ b/proxy/src/main/java/io/reshapr/proxy/registry/ConfigurationEntry.java
@@ -31,13 +31,14 @@ public record ConfigurationEntry(
       String apiKey,
       OAuth2ConfigurationEntry oauth2Configuration,
       SecretEntry backendSecret,
-      boolean audit) {
+      boolean audit,
+      CachingConfigurationEntry cachingConfiguration) {
 
 
    public ConfigurationEntry(String id, String name, String backendEndpoint, Long backendTimeout,
                              List<String> excludedOperations, List<String> includedOperations,
                              String apiKey, OAuth2ConfigurationEntry oauth2Configuration, SecretEntry backendSecret) {
-      this(id, name, backendEndpoint, backendTimeout, excludedOperations, includedOperations, apiKey, oauth2Configuration, backendSecret, false);
+      this(id, name, backendEndpoint, backendTimeout, excludedOperations, includedOperations, apiKey, oauth2Configuration, backendSecret, false, null);
    }
 
    @Override
@@ -49,5 +50,28 @@ public record ConfigurationEntry(
 
    private String apiKeyString() {
       return (apiKey != null ? "*******" : "null");
+   }
+
+   /**
+    * Caching directives forwarded from the ConfigurationPlan to MCP responses.
+    * Both fields are optional; when null the proxy falls back to the defaults.
+    *
+    * @param ttlMs      Time-to-live in milliseconds.
+    * @param cacheScope Cache scope (e.g. "public" or "private").
+    */
+   public record CachingConfigurationEntry(Long ttlMs, String cacheScope) {
+
+      public static final long DEFAULT_TTL_MS = 30_000L;
+      public static final String DEFAULT_CACHE_SCOPE = "public";
+
+      /** Returns {@code ttlMs} if set, otherwise the default (30 000 ms). */
+      public long effectiveTtlMs() {
+         return ttlMs != null ? ttlMs : DEFAULT_TTL_MS;
+      }
+
+      /** Returns {@code cacheScope} if set, otherwise the default ("public"). */
+      public String effectiveCacheScope() {
+         return cacheScope != null ? cacheScope : DEFAULT_CACHE_SCOPE;
+      }
    }
 }

--- a/proxy/src/main/java/io/reshapr/proxy/registry/ConfigurationEntry.java
+++ b/proxy/src/main/java/io/reshapr/proxy/registry/ConfigurationEntry.java
@@ -32,7 +32,7 @@ public record ConfigurationEntry(
       OAuth2ConfigurationEntry oauth2Configuration,
       SecretEntry backendSecret,
       boolean audit,
-      CachingConfigurationEntry cachingConfiguration) {
+      CachePolicyEntry cachePolicy) {
 
 
    public ConfigurationEntry(String id, String name, String backendEndpoint, Long backendTimeout,
@@ -59,7 +59,7 @@ public record ConfigurationEntry(
     * @param ttlMs      Time-to-live in milliseconds.
     * @param cacheScope Cache scope (e.g. "public" or "private").
     */
-   public record CachingConfigurationEntry(Long ttlMs, String cacheScope) {
+   public record CachePolicyEntry(Long ttlMs, String cacheScope) {
 
       public static final long DEFAULT_TTL_MS = 30_000L;
       public static final String DEFAULT_CACHE_SCOPE = "public";

--- a/proxy/src/main/java/io/reshapr/proxy/registry/ConfigurationEntry.java
+++ b/proxy/src/main/java/io/reshapr/proxy/registry/ConfigurationEntry.java
@@ -41,6 +41,12 @@ public record ConfigurationEntry(
       this(id, name, backendEndpoint, backendTimeout, excludedOperations, includedOperations, apiKey, oauth2Configuration, backendSecret, false, null);
    }
 
+   public ConfigurationEntry(String id, String name, String backendEndpoint, Long backendTimeout,
+                             List<String> excludedOperations, List<String> includedOperations,
+                             String apiKey, OAuth2ConfigurationEntry oauth2Configuration, SecretEntry backendSecret, boolean audit) {
+      this(id, name, backendEndpoint, backendTimeout, excludedOperations, includedOperations, apiKey, oauth2Configuration, backendSecret, audit, null);
+   }
+
    @Override
    public String toString() {
       return "ConfigurationEntry[id=" + id + ", name= " + name + ", backendEndpoint=" + backendEndpoint

--- a/proxy/src/main/java/io/reshapr/proxy/registry/Mappers.java
+++ b/proxy/src/main/java/io/reshapr/proxy/registry/Mappers.java
@@ -17,6 +17,7 @@ package io.reshapr.proxy.registry;
 
 import io.reshapr.discovery.exposition.v1.Artifact;
 import io.reshapr.discovery.exposition.v1.ArtifactType;
+import io.reshapr.discovery.exposition.v1.CachingConfiguration;
 import io.reshapr.discovery.exposition.v1.Configuration;
 import io.reshapr.discovery.exposition.v1.Secret;
 import io.reshapr.discovery.exposition.v1.Service;
@@ -43,7 +44,16 @@ public interface Mappers {
    @Mapping(target = "excludedOperations", source = "excludedOperationsList")
    @Mapping(target = "includedOperations", source = "includedOperationsList")
    @Mapping(target = "backendTimeout", expression = "java(configuration.hasBackendTimeout() ? configuration.getBackendTimeout() : null)")
+   @Mapping(target = "cachingConfiguration", expression = "java(configuration.hasCachingConfiguration() ? toCachingConfigurationEntry(configuration.getCachingConfiguration()) : null)")
    public ConfigurationEntry toConfigurationEntry(Configuration configuration);
+
+   /** Maps the gRPC {@link CachingConfiguration} optional fields to a {@link ConfigurationEntry.CachingConfigurationEntry}. */
+   default ConfigurationEntry.CachingConfigurationEntry toCachingConfigurationEntry(CachingConfiguration cc) {
+      if (cc == null) return null;
+      Long ttlMs = cc.hasTtlMs() ? cc.getTtlMs() : null;
+      String cacheScope = cc.hasCacheScope() ? cc.getCacheScope() : null;
+      return new ConfigurationEntry.CachingConfigurationEntry(ttlMs, cacheScope);
+   }
 
    @Mapping(target = "authorizationServers", source = "authorizationServersList")
    @Mapping(target = "scopes", source = "scopesList")

--- a/proxy/src/main/java/io/reshapr/proxy/registry/Mappers.java
+++ b/proxy/src/main/java/io/reshapr/proxy/registry/Mappers.java
@@ -17,7 +17,7 @@ package io.reshapr.proxy.registry;
 
 import io.reshapr.discovery.exposition.v1.Artifact;
 import io.reshapr.discovery.exposition.v1.ArtifactType;
-import io.reshapr.discovery.exposition.v1.CachingConfiguration;
+import io.reshapr.discovery.exposition.v1.CachePolicy;
 import io.reshapr.discovery.exposition.v1.Configuration;
 import io.reshapr.discovery.exposition.v1.Secret;
 import io.reshapr.discovery.exposition.v1.Service;
@@ -44,15 +44,15 @@ public interface Mappers {
    @Mapping(target = "excludedOperations", source = "excludedOperationsList")
    @Mapping(target = "includedOperations", source = "includedOperationsList")
    @Mapping(target = "backendTimeout", expression = "java(configuration.hasBackendTimeout() ? configuration.getBackendTimeout() : null)")
-   @Mapping(target = "cachingConfiguration", expression = "java(configuration.hasCachingConfiguration() ? toCachingConfigurationEntry(configuration.getCachingConfiguration()) : null)")
+   @Mapping(target = "cachePolicy", expression = "java(configuration.hasCachePolicy() ? toCachePolicyEntry(configuration.getCachePolicy()) : null)")
    public ConfigurationEntry toConfigurationEntry(Configuration configuration);
 
-   /** Maps the gRPC {@link CachingConfiguration} optional fields to a {@link ConfigurationEntry.CachingConfigurationEntry}. */
-   default ConfigurationEntry.CachingConfigurationEntry toCachingConfigurationEntry(CachingConfiguration cc) {
+   /** Maps the gRPC {@link CachePolicy} optional fields to a {@link ConfigurationEntry.CachePolicyEntry}. */
+   default ConfigurationEntry.CachePolicyEntry toCachePolicyEntry(CachePolicy cc) {
       if (cc == null) return null;
       Long ttlMs = cc.hasTtlMs() ? cc.getTtlMs() : null;
       String cacheScope = cc.hasCacheScope() ? cc.getCacheScope() : null;
-      return new ConfigurationEntry.CachingConfigurationEntry(ttlMs, cacheScope);
+      return new ConfigurationEntry.CachePolicyEntry(ttlMs, cacheScope);
    }
 
    @Mapping(target = "authorizationServers", source = "authorizationServersList")

--- a/proxy/src/main/resources/application.properties
+++ b/proxy/src/main/resources/application.properties
@@ -89,6 +89,7 @@ reshapr.ctrl.host=localhost
 reshapr.ctrl.port=5555
 reshapr.ctrl.token=reshapr-my-super-secret-token
 reshapr.ctrl.tls.plain-text=${RESHAPR_CTRL_TLS_PLAINTEXT:true}
-
 reshapr.version=${project.version}
 reshapr.buildTimestamp=${maven.build.timestamp}
+
+%test.maven.build.timestamp=test

--- a/web-ui/src/lib/components/plan/PlanEditor.svelte
+++ b/web-ui/src/lib/components/plan/PlanEditor.svelte
@@ -79,6 +79,10 @@
 	let audit = $state(false);
 	let backendSecretId = $state('');
 
+	// ── Caching configuration (MCP >= 2026-07-28) ───────────────────────────────
+	let cachingTtlMs = $state('');
+	let cachingScope = $state<'public' | 'private' | ''>('');
+
 	/** 'include' exposes only the selected operations, 'exclude' hides the selected ones. */
 	let opsMode = $state<'include' | 'exclude'>('include');
 	let selectedOps = $state<string[]>([]);
@@ -288,6 +292,11 @@
 		audit = plan.audit === true;
 		backendSecretId = typeof plan.backendSecretId === 'string' ? plan.backendSecretId : '';
 
+		// Caching configuration
+		const cc = plan.cachingConfiguration as Record<string, unknown> | null | undefined;
+		cachingTtlMs = cc?.ttlMs != null ? String(cc.ttlMs) : '';
+		cachingScope = cc?.cacheScope === 'private' ? 'private' : cc?.cacheScope === 'public' ? 'public' : '';
+
 		const included = Array.isArray(plan.includedOperations)
 			? plan.includedOperations.map(String).filter(Boolean)
 			: [];
@@ -401,6 +410,17 @@
 		else delete body.backendTimeout;
 
 		body.audit = audit;
+
+		// Caching configuration — send only when at least one field is set; null to clear.
+		const ttlNum = cachingTtlMs.trim();
+		if (ttlNum || cachingScope) {
+			body.cachingConfiguration = {
+				...(ttlNum && !Number.isNaN(Number(ttlNum)) ? { ttlMs: Number(ttlNum) } : {}),
+				...(cachingScope ? { cacheScope: cachingScope } : {})
+			};
+		} else {
+			body.cachingConfiguration = null;
+		}
 
 		delete body.includedOperations;
 		delete body.excludedOperations;
@@ -629,6 +649,40 @@
 					<Checkbox checked={audit} disabled={loading} onCheckedChange={(v) => (audit = v === true)} />
 					<span>Enable audit log</span>
 				</label>
+			</div>
+
+			<!-- ── Caching configuration ─────────────────────────────────────── -->
+			<div class="border-t pt-4">
+				<p class="mb-3 text-sm font-medium">Caching configuration</p>
+				<p class="mb-4 text-xs text-muted-foreground">
+					Client-side cache hints sent on MCP list/read responses (protocol ≥ 2026-07-28).
+					Leave blank to use the defaults (30 000 ms, public).
+				</p>
+				<div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
+					<div class="space-y-2">
+						<Label for="cachingTtlMs">Cache TTL (ms)</Label>
+						<Input
+							id="cachingTtlMs"
+							bind:value={cachingTtlMs}
+							inputmode="numeric"
+							placeholder="Default: 30000"
+							disabled={loading}
+						/>
+					</div>
+					<div class="space-y-2">
+						<Label for="cachingScope">Cache scope</Label>
+						<select
+							id="cachingScope"
+							bind:value={cachingScope}
+							disabled={loading}
+							class="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
+						>
+							<option value="">Default (public)</option>
+							<option value="public">public</option>
+							<option value="private">private</option>
+						</select>
+					</div>
+				</div>
 			</div>
 		</Card.Content>
 	</Card.Root>

--- a/web-ui/src/lib/components/plan/PlanEditor.svelte
+++ b/web-ui/src/lib/components/plan/PlanEditor.svelte
@@ -293,7 +293,7 @@
 		backendSecretId = typeof plan.backendSecretId === 'string' ? plan.backendSecretId : '';
 
 		// Caching configuration
-		const cc = plan.cachingConfiguration as Record<string, unknown> | null | undefined;
+		const cc = plan.cachePolicy as Record<string, unknown> | null | undefined;
 		cachingTtlMs = cc?.ttlMs != null ? String(cc.ttlMs) : '';
 		cachingScope = cc?.cacheScope === 'private' ? 'private' : cc?.cacheScope === 'public' ? 'public' : '';
 
@@ -414,12 +414,12 @@
 		// Caching configuration — send only when at least one field is set; null to clear.
 		const ttlNum = cachingTtlMs.trim();
 		if (ttlNum || cachingScope) {
-			body.cachingConfiguration = {
+			body.cachePolicy = {
 				...(ttlNum && !Number.isNaN(Number(ttlNum)) ? { ttlMs: Number(ttlNum) } : {}),
 				...(cachingScope ? { cacheScope: cachingScope } : {})
 			};
 		} else {
-			body.cachingConfiguration = null;
+			body.cachePolicy = null;
 		}
 
 		delete body.includedOperations;


### PR DESCRIPTION
Closes #323

## Description

This PR introduces support for customizing the MCP client-side caching configuration (`ttlMs` and `cacheScope`) per Configuration Plan, as requested in #323. Previously, caching hints for tools/list and tools/read were hardcoded to `30000ms` and `public`.

With this change, administrators can explicitly define these settings in the UI or via the API, which the proxy will use during MCP interactions (protocol ≥ `2026-07-28`).

## Changes

* **Database**: Added `caching_configuration` (JSONB) to the `configuration_plan` table (Flyway V1.5.0).
* **API / Control Plane**: Added `cachingConfiguration` field to `ConfigurationPlan`, `ConfigurationPlanDTO`, and `eds-v1.proto`.
* **Proxy**: Removed hardcoded values in `McpController` and wired it to read from the dynamically loaded `ConfigurationEntry`.
* **Web UI**: Added "Cache TTL (ms)" and "Cache scope" inputs to the Operations section in `PlanEditor.svelte`.

## Verification

<img width="1649" height="524" alt="Screenshot from 2026-08-25 14-26-08" src="https://github.com/user-attachments/assets/ca107693-2bdf-4535-a712-cb8f6d55a459" />

```console
vaishnavsk@vaishnav88:~$ curl -s -X POST http://localhost:7777/mcp/reshapr/dummy/1.0 \
  -H "Content-Type: application/json" \
  -H "MCP-Protocol-Version: 2026-07-28" \
  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}' | python3 -m json.tool
{
    "jsonrpc": "2.0",
    "id": 1,
    "result": {
        "resultType": "complete",
        "tools": [
            {
                "name": "get_hello",
                "inputSchema": {
                    "type": "object",
                    "properties": {},
                    "required": [],
                    "additionalProperties": false
                }
            }
        ],
        "ttlMs": 120000,
        "cacheScope": "private"
    }
}
```