### PR TITLE
fix: Accept RFC 9068 `at+jwt` access tokens in OAuth2 validation

### DIFF
--- a/.github/workflows/build-gateway-ghcr.yml
+++ b/.github/workflows/build-gateway-ghcr.yml
@@ -1,0 +1,105 @@
+# Fork-only gateway (proxy) image build.
+#
+# Upstream publishes its images from build-containers.yml, which is gated on
+# `github.repository_owner == 'reshaprio'` and pushes to Quay and Docker Hub
+# using organisation secrets. Forks get nothing from it, so this workflow
+# builds the proxy and publishes it to the fork owner's GitHub Container
+# Registry using the built-in GITHUB_TOKEN — no extra secrets required.
+name: build-gateway-ghcr
+
+on:
+  push:
+    branches:
+      - main
+      - 'fix/**'
+    paths-ignore:
+      - '.gitignore'
+      - 'LICENSE'
+      - '*.md'
+  workflow_dispatch:
+
+permissions: read-all
+
+jobs:
+  build-gateway:
+    # Never run on upstream: it has its own publishing pipeline.
+    if: github.repository_owner != 'reshaprio'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Get current date
+        id: date
+        run: echo "date=$(date +'%Y-%m-%dT%H:%M:%SZ')" >> $GITHUB_OUTPUT
+
+      - name: Checkout Code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up JDK 25 for x64
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
+        with:
+          java-version: '25'
+          distribution: 'temurin'
+          architecture: x64
+          cache: maven
+
+      # Dockerfile.jvm is a runtime-only image: it COPYs target/quarkus-app,
+      # so the Maven build has to happen here first.
+      - name: Build Java components
+        run: mvn -B -DskipTests clean install
+
+      # GHCR rejects uppercase path segments, so the owner is lowercased.
+      - name: Compute image tags
+        id: tags
+        run: |
+          set -x
+          OWNER="$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')"
+          IMAGE="ghcr.io/${OWNER}/reshapr-proxy"
+          REF_TAG="$(echo "${GITHUB_REF_NAME}" | tr '/' '-' | tr '[:upper:]' '[:lower:]')"
+          TAGS="${IMAGE}:${REF_TAG},${IMAGE}:sha-${GITHUB_SHA::7}"
+          if [[ "${GITHUB_REF}" == 'refs/heads/main' ]]; then
+            TAGS="${TAGS},${IMAGE}:nightly"
+          fi
+          echo "image=${IMAGE}" >> "$GITHUB_OUTPUT"
+          echo "tags=${TAGS}" >> "$GITHUB_OUTPUT"
+
+      - name: Login to GitHub Container Registry
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login -u "${{ github.actor }}" --password-stdin ghcr.io
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+        with:
+          driver-opts: network=host
+
+      - name: Build and push container image for proxy
+        id: build-and-push-proxy
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: ${{github.workspace}}/proxy
+          sbom: true
+          push: true
+          provenance: mode=max
+          platforms: linux/amd64,linux/arm64
+          file: proxy/src/main/docker/Dockerfile.jvm
+          labels: |
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.created=${{ steps.date.outputs.date }}
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+          tags: ${{ steps.tags.outputs.tags }}
+
+      - name: Summarise published image
+        run: |
+          {
+            echo "### Gateway image published"
+            echo ""
+            echo "| field | value |"
+            echo "| --- | --- |"
+            echo "| tags | \`${{ steps.tags.outputs.tags }}\` |"
+            echo "| digest | \`${{ steps.build-and-push-proxy.outputs.digest }}\` |"
+            echo "| revision | \`${{ github.sha }}\` |"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/install/docker-compose-all-in-one.yml
+++ b/install/docker-compose-all-in-one.yml
@@ -49,7 +49,7 @@ services:
       retries: 3
 
   gateway-01:
-    image: registry.reshapr.io/reshapr/reshapr-proxy:nightly
+    image: ghcr.io/guillaumeexia/reshapr-proxy:nightly
     container_name: reshapr-gateway-01
     extra_hosts:
       - "host.docker.internal:host-gateway"

--- a/proxy/src/main/java/io/reshapr/proxy/security/SecureEndpointFilter.java
+++ b/proxy/src/main/java/io/reshapr/proxy/security/SecureEndpointFilter.java
@@ -24,9 +24,11 @@ import io.reshapr.proxy.registry.OAuth2ConfigurationEntry;
 import io.reshapr.proxy.registry.ServiceEntry;
 
 import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JOSEObjectType;
 import com.nimbusds.jose.JWSAlgorithm;
 import com.nimbusds.jose.jwk.source.JWKSourceBuilder;
 import com.nimbusds.jose.proc.BadJOSEException;
+import com.nimbusds.jose.proc.DefaultJOSEObjectTypeVerifier;
 import com.nimbusds.jose.proc.JWSKeySelector;
 import com.nimbusds.jose.proc.JWSVerificationKeySelector;
 import com.nimbusds.jose.proc.SecurityContext;
@@ -212,6 +214,11 @@ public class SecureEndpointFilter implements ContainerRequestFilter {
             JWS_SUPPORTED_ALGORITHMS,
             JWKSourceBuilder.create(jwksUri).retrying(true).build());
       jwtProcessor.setJWSKeySelector(keySelector);
+
+      // RFC 9068 access tokens carry an "at+jwt" type header; Nimbus only accepts "JWT" or an
+      // absent header by default. The trailing null keeps tokens without a type header valid.
+      jwtProcessor.setJWSTypeVerifier(new DefaultJOSEObjectTypeVerifier<>(
+            JOSEObjectType.JWT, new JOSEObjectType("at+jwt"), null));
 
       // Set the required JWT claims for access tokens
       jwtProcessor.setJWTClaimsSetVerifier(new MultipleIssuerClaimsVerifier(


### PR DESCRIPTION
Nimbus' DefaultJWTProcessor defaults its JWS type verifier to DefaultJOSEObjectTypeVerifier.JWT, which only allows a `typ` header of "JWT" or no header at all. Access tokens issued per RFC 9068 carry `typ: "at+jwt"`, so every one of them was rejected with a BadJOSEException before any claim was inspected, and the gateway answered with an empty 400.

This broke MCP clients against spec-compliant authorization servers. Auth0 APIs using the `rfc9068_profile` token dialect are one case, and the dialect cannot be traded away: the alternative `access_token` dialect emits no `jti`, which JWT_VERIFIED_CLAIMS requires.

Declare "at+jwt" alongside "JWT" as accepted types. The trailing null keeps tokens with no `typ` header valid, and unknown types are still rejected.