### PR TITLE
fix: allow `at+jwt` as valid token type and remove `jti` check

### DIFF
--- a/proxy/src/main/java/io/reshapr/proxy/security/SecureEndpointFilter.java
+++ b/proxy/src/main/java/io/reshapr/proxy/security/SecureEndpointFilter.java
@@ -24,10 +24,12 @@ import io.reshapr.proxy.registry.OAuth2ConfigurationEntry;
 import io.reshapr.proxy.registry.ServiceEntry;
 
 import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JOSEObjectType;
 import com.nimbusds.jose.JWSAlgorithm;
 import com.nimbusds.jose.jwk.source.JWKSource;
 import com.nimbusds.jose.jwk.source.JWKSourceBuilder;
 import com.nimbusds.jose.proc.BadJOSEException;
+import com.nimbusds.jose.proc.DefaultJOSEObjectTypeVerifier;
 import com.nimbusds.jose.proc.JWSKeySelector;
 import com.nimbusds.jose.proc.JWSVerificationKeySelector;
 import com.nimbusds.jose.proc.SecurityContext;
@@ -213,6 +215,11 @@ public class SecureEndpointFilter implements ContainerRequestFilter {
 
       // Create a JWT processor for the access tokens
       ConfigurableJWTProcessor<SecurityContext> jwtProcessor = new DefaultJWTProcessor<>();
+      jwtProcessor.setJWSTypeVerifier(new DefaultJOSEObjectTypeVerifier<>(
+            JOSEObjectType.JWT,
+            new JOSEObjectType("at+jwt"),
+            null
+      ));
 
       // Configure the JWT processor with a key selector to feed matching public
       // RSA keys sourced from the JWK set URL.

--- a/proxy/src/main/java/io/reshapr/proxy/security/SecureEndpointFilter.java
+++ b/proxy/src/main/java/io/reshapr/proxy/security/SecureEndpointFilter.java
@@ -91,8 +91,7 @@ public class SecureEndpointFilter implements ContainerRequestFilter {
    private static final Set<String> JWT_VERIFIED_CLAIMS = Set.of(
          JWTClaimNames.SUBJECT,
          JWTClaimNames.ISSUED_AT,
-         JWTClaimNames.EXPIRATION_TIME,
-         JWTClaimNames.JWT_ID
+         JWTClaimNames.EXPIRATION_TIME
    );
 
    /* Cache of JWKSource instances keyed by JWK Set URL to avoid reloading keys for each request. */

--- a/proxy/src/test/java/io/reshapr/proxy/security/SecureEndpointFilterTest.java
+++ b/proxy/src/test/java/io/reshapr/proxy/security/SecureEndpointFilterTest.java
@@ -401,7 +401,6 @@ class SecureEndpointFilterTest {
       }
 
       @Test
-      @Disabled("Pending fix: make the jti claim optional (no replay cache uses it; several AS do not emit it)")
       @DisplayName("Token without jti claim is accepted")
       void tokenWithoutJtiIsAccepted() throws Exception {
          registerOAuth2Exposition(null);

--- a/proxy/src/test/java/io/reshapr/proxy/security/SecureEndpointFilterTest.java
+++ b/proxy/src/test/java/io/reshapr/proxy/security/SecureEndpointFilterTest.java
@@ -389,7 +389,6 @@ class SecureEndpointFilterTest {
       }
 
       @Test
-      @Disabled("Pending fix: register a JOSEObjectTypeVerifier allowing at+jwt (RFC 9068) on the JWT processor")
       @DisplayName("typ: at+jwt (RFC 9068 / Auth0, Okta, Spring AS) is accepted")
       void atPlusJwtTypIsAccepted() throws Exception {
          registerOAuth2Exposition(null);


### PR DESCRIPTION
fixes #382
fixes #384 