### PR TITLE
Add audience validation support for OAuth2

### DIFF
--- a/api/src/main/proto/eds-v1.proto
+++ b/api/src/main/proto/eds-v1.proto
@@ -58,6 +58,8 @@ message OAuth2Configuration {
   repeated string authorizationServers = 1;
   string jwksUri = 2;
   repeated string scopes = 3;
+  repeated string staticAudiences = 4;
+  bool disableAudienceValidation = 5;
 }
 
 // Secret represents sensitive information required for accessing the backend service

--- a/control-plane/src/main/java/io/reshapr/ctrl/model/ConfigurationPlan.java
+++ b/control-plane/src/main/java/io/reshapr/ctrl/model/ConfigurationPlan.java
@@ -106,7 +106,9 @@ public class ConfigurationPlan extends TenantAwareEntity {
    public record OAuth2Configuration(
          List<String> authorizationServers,
          String jwksUri,
-         List<String> scopes
+         List<String> scopes,
+         List<String> staticAudiences,
+         boolean disableAudienceValidation
    ) {
    }
 

--- a/control-plane/src/main/java/io/reshapr/ctrl/rest/v1/OAuth2ConfigurationDTO.java
+++ b/control-plane/src/main/java/io/reshapr/ctrl/rest/v1/OAuth2ConfigurationDTO.java
@@ -33,6 +33,8 @@ public record OAuth2ConfigurationDTO(
       List<@HttpUrl(message = "Authorization server must be a valid HTTP(S) URL") String> authorizationServers,
       @HttpUrl(message = "JWKS URI endpoint must be a valid HTTP(S) URL")
       String jwksUri,
-      List<String> scopes
+      List<String> scopes,
+      List<String> staticAudiences,
+      boolean disableAudienceValidation
 ) {
 }

--- a/control-plane/src/main/java/io/reshapr/ctrl/service/ConfigurationPlanManagerService.java
+++ b/control-plane/src/main/java/io/reshapr/ctrl/service/ConfigurationPlanManagerService.java
@@ -161,7 +161,9 @@ public class ConfigurationPlanManagerService {
          newPlan.oauth2Configuration = new ConfigurationPlan.OAuth2Configuration(
                sourcePlan.oauth2Configuration.authorizationServers() != null ? new java.util.ArrayList<>(sourcePlan.oauth2Configuration.authorizationServers()) : null,
                sourcePlan.oauth2Configuration.jwksUri(),
-               sourcePlan.oauth2Configuration.scopes() != null ? new java.util.ArrayList<>(sourcePlan.oauth2Configuration.scopes()) : null
+               sourcePlan.oauth2Configuration.scopes() != null ? new java.util.ArrayList<>(sourcePlan.oauth2Configuration.scopes()) : null,
+               sourcePlan.oauth2Configuration.staticAudiences() != null ? new java.util.ArrayList<>(sourcePlan.oauth2Configuration.staticAudiences()) : null,
+               sourcePlan.oauth2Configuration.disableAudienceValidation()
          );
       }
 

--- a/control-plane/src/test/java/io/reshapr/ctrl/service/ConfigurationPlanManagerServiceTest.java
+++ b/control-plane/src/test/java/io/reshapr/ctrl/service/ConfigurationPlanManagerServiceTest.java
@@ -184,8 +184,12 @@ class ConfigurationPlanManagerServiceTest {
 
       ConfigurationPlan plan = newPlan("elicitation-with-oauth");
       plan.oauth2Configuration = new ConfigurationPlan.OAuth2Configuration(
-            List.of("https://as.example.com"), "https://as.example.com/jwks", List.of("read"));
-
+                        List.of("http://localhost:8080/auth"),
+                        "http://localhost:8080/jwks",
+                        List.of("read", "write"),
+                        null,
+                        false
+                  );
       ConfigurationPlan created = managerService.createConfigurationPlan(plan, serviceId, secretId, false);
       assertNotNull(created.id);
       assertNotNull(created.backendSecret);

--- a/proxy/src/main/java/io/reshapr/proxy/audit/AuthenticationFailureAuditEvent.java
+++ b/proxy/src/main/java/io/reshapr/proxy/audit/AuthenticationFailureAuditEvent.java
@@ -48,6 +48,7 @@ public record AuthenticationFailureAuditEvent(
    public static final String REASON_INVALID_TOKEN = "invalid_token";
    public static final String REASON_FORBIDDEN_RESOURCE = "forbidden_resource";
    public static final String REASON_FORBIDDEN_SERVICE = "forbidden_service";
+   public static final String REASON_FORBIDDEN_AUDIENCE = "forbidden_audience";
    public static final String REASON_MISSING_SCOPE = "missing_scope";
 }
 

--- a/proxy/src/main/java/io/reshapr/proxy/registry/Mappers.java
+++ b/proxy/src/main/java/io/reshapr/proxy/registry/Mappers.java
@@ -57,6 +57,7 @@ public interface Mappers {
 
    @Mapping(target = "authorizationServers", source = "authorizationServersList")
    @Mapping(target = "scopes", source = "scopesList")
+   @Mapping(target = "staticAudiences", source = "staticAudiencesList")
    public OAuth2ConfigurationEntry toOAuth2ConfigurationEntry(OAuth2Configuration oauth2Configuration);
 
    public SecretEntry toSecret(Secret secret);

--- a/proxy/src/main/java/io/reshapr/proxy/registry/OAuth2ConfigurationEntry.java
+++ b/proxy/src/main/java/io/reshapr/proxy/registry/OAuth2ConfigurationEntry.java
@@ -25,6 +25,8 @@ import java.util.List;
 public record OAuth2ConfigurationEntry(
       List<String> authorizationServers,
       String jwksUri,
-      List<String> scopes
+      List<String> scopes,
+      List<String> staticAudiences,
+      boolean disableAudienceValidation
 ) {
 }

--- a/proxy/src/main/java/io/reshapr/proxy/security/SecureEndpointFilter.java
+++ b/proxy/src/main/java/io/reshapr/proxy/security/SecureEndpointFilter.java
@@ -58,8 +58,11 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
- * SecureEndpointFilter is a JAX-RS filter that applies security checks to incoming requests.
- * The filter can be used to enforce security policies, such as authentication and authorization.
+ * SecureEndpointFilter is a JAX-RS filter that applies security checks to
+ * incoming requests.
+ * The filter can be used to enforce security policies, such as authentication
+ * and authorization.
+ * 
  * @author laurent
  */
 @Provider
@@ -75,7 +78,10 @@ public class SecureEndpointFilter implements ContainerRequestFilter {
    /** Request context property key for the authenticated user ID. */
    public static final String USER_ID_PROPERTY = "reshapr.auth.userId";
 
-   /** Request context property key for the authenticated token issuer (JWT {@code iss} claim). */
+   /**
+    * Request context property key for the authenticated token issuer (JWT
+    * {@code iss} claim).
+    */
    public static final String ISSUER_PROPERTY = "reshapr.auth.issuer";
 
    private static final Set<JWSAlgorithm> JWS_SUPPORTED_ALGORITHMS = Set.of(
@@ -84,16 +90,17 @@ public class SecureEndpointFilter implements ContainerRequestFilter {
          JWSAlgorithm.RS512,
          JWSAlgorithm.PS256,
          JWSAlgorithm.PS384,
-         JWSAlgorithm.PS512
-   );
+         JWSAlgorithm.PS512);
    private static final Set<String> JWT_VERIFIED_CLAIMS = Set.of(
          JWTClaimNames.SUBJECT,
          JWTClaimNames.ISSUED_AT,
          JWTClaimNames.EXPIRATION_TIME,
-         JWTClaimNames.JWT_ID
-   );
+         JWTClaimNames.JWT_ID);
 
-   /* Cache of JWKSource instances keyed by JWK Set URL to avoid reloading keys for each request. */
+   /*
+    * Cache of JWKSource instances keyed by JWK Set URL to avoid reloading keys for
+    * each request.
+    */
    private final ConcurrentHashMap<String, JWKSource<SecurityContext>> jwkSources = new ConcurrentHashMap<>();
 
    private final GatewayRegistry gatewayRegistry;
@@ -129,7 +136,8 @@ public class SecureEndpointFilter implements ContainerRequestFilter {
             // 2 segments: /mcp/{organizationId}/{expositionName}
             exposition = gatewayRegistry.getExpositionByName(parts[0], parts[1]);
          } else if (parts.length == 3) {
-            // 3 segments (legacy): /mcp/{organizationId}/{service}/{version} -> elected exposition.
+            // 3 segments (legacy): /mcp/{organizationId}/{service}/{version} -> elected
+            // exposition.
             // If serviceName was encoded with '+' instead of '%20', remove them.
             if (parts[1].contains("+")) {
                parts[1] = parts[1].replace('+', ' ');
@@ -163,27 +171,34 @@ public class SecureEndpointFilter implements ContainerRequestFilter {
    }
 
    private boolean isSecuredWithOAuth2(ConfigurationEntry configuration) {
-      return (configuration.oauth2Configuration() != null && !configuration.oauth2Configuration().authorizationServers().isEmpty());
+      return (configuration.oauth2Configuration() != null
+            && !configuration.oauth2Configuration().authorizationServers().isEmpty());
    }
 
-   private void checkAPIKeyValidity(ServiceEntry service, ConfigurationEntry configuration, ContainerRequestContext ctx) {
+   private void checkAPIKeyValidity(ServiceEntry service, ConfigurationEntry configuration,
+         ContainerRequestContext ctx) {
       // Check for API key in headers.
       String apiKey = ctx.getHeaderString(API_KEY_HEADER);
-      boolean valid =  configuration.apiKey() != null && configuration.apiKey().equals(apiKey);
+      boolean valid = configuration.apiKey() != null && configuration.apiKey().equals(apiKey);
       if (!valid) {
          logger.warnf("Invalid or missing API key for configuration with ID: '%s'", configuration.id());
-         emitAuthenticationFailureAuditEvent(service, configuration, AuthenticationFailureAuditEvent.REASON_INVALID_API_KEY, Response.Status.UNAUTHORIZED.getStatusCode(), ctx);
+         emitAuthenticationFailureAuditEvent(service, configuration,
+               AuthenticationFailureAuditEvent.REASON_INVALID_API_KEY, Response.Status.UNAUTHORIZED.getStatusCode(),
+               ctx);
          ctx.abortWith(Response.status(Response.Status.UNAUTHORIZED).build());
       }
    }
 
-   private void checkOAuth2Validity(ServiceEntry service, ConfigurationEntry configuration, ContainerRequestContext ctx) {
+   private void checkOAuth2Validity(ServiceEntry service, ConfigurationEntry configuration,
+         ContainerRequestContext ctx) {
       String fqdnScheme = WebUtils.getHTTPScheme(fqdns.getFirst());
       String authorizationHeader = ctx.getHeaderString(HttpHeaders.AUTHORIZATION);
 
       if (authorizationHeader == null || !authorizationHeader.startsWith("Bearer ")) {
          logger.warnf("Missing or invalid Authorization header for configuration with ID: '%s'", configuration.id());
-         emitAuthenticationFailureAuditEvent(service, configuration, AuthenticationFailureAuditEvent.REASON_MISSING_BEARER, Response.Status.UNAUTHORIZED.getStatusCode(), ctx);
+         emitAuthenticationFailureAuditEvent(service, configuration,
+               AuthenticationFailureAuditEvent.REASON_MISSING_BEARER, Response.Status.UNAUTHORIZED.getStatusCode(),
+               ctx);
          logger.warnf("Redirecting to '%s'", fqdnScheme
                + fqdns.getFirst() + "/.well-known/oauth-protected-resource" + ctx.getUriInfo().getPath());
          ctx.abortWith(Response.status(Response.Status.UNAUTHORIZED)
@@ -221,27 +236,35 @@ public class SecureEndpointFilter implements ContainerRequestFilter {
       jwtProcessor.setJWSKeySelector(keySelector);
 
       // Set the required JWT claims for access tokens
+      Set<String> requiredClaims = new java.util.HashSet<>(JWT_VERIFIED_CLAIMS);
+      if (!oauth2Config.disableAudienceValidation()) {
+         requiredClaims.add(JWTClaimNames.AUDIENCE);
+      }
       jwtProcessor.setJWTClaimsSetVerifier(new MultipleIssuerClaimsVerifier(
             oauth2Config.authorizationServers(),
-            JWT_VERIFIED_CLAIMS
-      ));
+            requiredClaims));
 
       JWTClaimsSet claimsSet;
       SecurityContext securityCtx = null;
       try {
          claimsSet = jwtProcessor.process(token, securityCtx);
       } catch (ParseException e) {
-         // Unparseable JWT: RFC 6750 classifies malformed tokens as invalid_token -> 401.
+         // Unparseable JWT: RFC 6750 classifies malformed tokens as invalid_token ->
+         // 401.
          logger.warnf("Malformed OAuth2 token received: %s", e.getMessage());
-         emitAuthenticationFailureAuditEvent(service, configuration, AuthenticationFailureAuditEvent.REASON_MALFORMED_TOKEN, Response.Status.UNAUTHORIZED.getStatusCode(), ctx);
+         emitAuthenticationFailureAuditEvent(service, configuration,
+               AuthenticationFailureAuditEvent.REASON_MALFORMED_TOKEN, Response.Status.UNAUTHORIZED.getStatusCode(),
+               ctx);
          ctx.abortWith(Response.status(Response.Status.UNAUTHORIZED)
                .header(HttpHeaders.WWW_AUTHENTICATE, bearerChallenge(ctx, "invalid_token"))
                .build());
          return;
       } catch (BadJOSEException e) {
-         // Well-formed but rejected: bad signature, expired, wrong issuer, missing claims... -> 401.
+         // Well-formed but rejected: bad signature, expired, wrong issuer, missing
+         // claims... -> 401.
          logger.warnf("Invalid OAuth2 token received: %s", e.getMessage());
-         emitAuthenticationFailureAuditEvent(service, configuration, AuthenticationFailureAuditEvent.REASON_INVALID_TOKEN, Response.Status.UNAUTHORIZED.getStatusCode(), ctx);
+         emitAuthenticationFailureAuditEvent(service, configuration,
+               AuthenticationFailureAuditEvent.REASON_INVALID_TOKEN, Response.Status.UNAUTHORIZED.getStatusCode(), ctx);
          ctx.abortWith(Response.status(Response.Status.UNAUTHORIZED)
                .header(HttpHeaders.WWW_AUTHENTICATE, bearerChallenge(ctx, "invalid_token"))
                .build());
@@ -249,26 +272,34 @@ public class SecureEndpointFilter implements ContainerRequestFilter {
       } catch (JOSEException e) {
          // Key sourcing failed or another internal exception.
          logger.warnf("Unable to verify OAuth2 token: %s", e.getMessage());
-         emitAuthenticationFailureAuditEvent(service, configuration, AuthenticationFailureAuditEvent.REASON_INVALID_TOKEN, Response.Status.UNAUTHORIZED.getStatusCode(), ctx);
+         emitAuthenticationFailureAuditEvent(service, configuration,
+               AuthenticationFailureAuditEvent.REASON_INVALID_TOKEN, Response.Status.UNAUTHORIZED.getStatusCode(), ctx);
          ctx.abortWith(Response.status(Response.Status.UNAUTHORIZED)
                .header(HttpHeaders.WWW_AUTHENTICATE, bearerChallenge(ctx, null))
                .build());
          return;
       }
 
-      // Now check the claimsSet for resource as per https://modelcontextprotocol.io/specification/2025-06-18/basic/authorization#token-handling
+      // Now check the claimsSet for resource as per
+      // https://modelcontextprotocol.io/specification/2025-06-18/basic/authorization#token-handling
       try {
          String resource = claimsSet.getClaimAsString("resource");
-         if (resource != null && !resource.equalsIgnoreCase(fqdnScheme + fqdns.getFirst() + ctx.getUriInfo().getPath())) {
-            logger.warnf("Invalid OAuth2 token received, resource claim does not match '%s'", fqdnScheme + fqdns.getFirst() + ctx.getUriInfo().getPath());
-            emitAuthenticationFailureAuditEvent(service, configuration, AuthenticationFailureAuditEvent.REASON_FORBIDDEN_RESOURCE, Response.Status.FORBIDDEN.getStatusCode(), ctx);
+         if (resource != null
+               && !resource.equalsIgnoreCase(fqdnScheme + fqdns.getFirst() + ctx.getUriInfo().getPath())) {
+            logger.warnf("Invalid OAuth2 token received, resource claim does not match '%s'",
+                  fqdnScheme + fqdns.getFirst() + ctx.getUriInfo().getPath());
+            emitAuthenticationFailureAuditEvent(service, configuration,
+                  AuthenticationFailureAuditEvent.REASON_FORBIDDEN_RESOURCE, Response.Status.FORBIDDEN.getStatusCode(),
+                  ctx);
             ctx.abortWith(Response.status(Response.Status.FORBIDDEN).build());
             return;
          }
       } catch (ParseException pe) {
          // Malformed token.
          logger.warnf("Bad OAuth2 token received, resource claim cannot be parsed as String", pe);
-         emitAuthenticationFailureAuditEvent(service, configuration, AuthenticationFailureAuditEvent.REASON_MALFORMED_TOKEN, Response.Status.UNAUTHORIZED.getStatusCode(), ctx);
+         emitAuthenticationFailureAuditEvent(service, configuration,
+               AuthenticationFailureAuditEvent.REASON_MALFORMED_TOKEN, Response.Status.UNAUTHORIZED.getStatusCode(),
+               ctx);
          ctx.abortWith(Response.status(Response.Status.UNAUTHORIZED).build());
          return;
       }
@@ -278,14 +309,18 @@ public class SecureEndpointFilter implements ContainerRequestFilter {
          String serviceID = claimsSet.getClaimAsString("serviceId");
          if (serviceID != null && !serviceID.equals(service.id())) {
             logger.warnf("Invalid OAuth2 token received, serviceId claim does not match service ID '%s'", service.id());
-            emitAuthenticationFailureAuditEvent(service, configuration, AuthenticationFailureAuditEvent.REASON_FORBIDDEN_SERVICE, Response.Status.FORBIDDEN.getStatusCode(), ctx);
+            emitAuthenticationFailureAuditEvent(service, configuration,
+                  AuthenticationFailureAuditEvent.REASON_FORBIDDEN_SERVICE, Response.Status.FORBIDDEN.getStatusCode(),
+                  ctx);
             ctx.abortWith(Response.status(Response.Status.FORBIDDEN).build());
             return;
          }
       } catch (ParseException pe) {
          // Malformed token.
          logger.warnf("Bad OAuth2 token received, serviceId claim cannot be parsed as String", pe);
-         emitAuthenticationFailureAuditEvent(service, configuration, AuthenticationFailureAuditEvent.REASON_MALFORMED_TOKEN, Response.Status.UNAUTHORIZED.getStatusCode(), ctx);
+         emitAuthenticationFailureAuditEvent(service, configuration,
+               AuthenticationFailureAuditEvent.REASON_MALFORMED_TOKEN, Response.Status.UNAUTHORIZED.getStatusCode(),
+               ctx);
          ctx.abortWith(Response.status(Response.Status.UNAUTHORIZED).build());
          return;
       }
@@ -310,28 +345,82 @@ public class SecureEndpointFilter implements ContainerRequestFilter {
          } catch (ParseException pe) {
             // Malformed token.
             logger.warnf("Bad OAuth2 token received, scope claim cannot be parsed as String or List<String>", pe);
-            emitAuthenticationFailureAuditEvent(service, configuration, AuthenticationFailureAuditEvent.REASON_MALFORMED_TOKEN, Response.Status.UNAUTHORIZED.getStatusCode(), ctx);
+            emitAuthenticationFailureAuditEvent(service, configuration,
+                  AuthenticationFailureAuditEvent.REASON_MALFORMED_TOKEN, Response.Status.UNAUTHORIZED.getStatusCode(),
+                  ctx);
             ctx.abortWith(Response.status(Response.Status.UNAUTHORIZED).build());
             return;
          }
 
          if (tokenScopes == null || tokenScopes.isEmpty()) {
-            logger.warnf("Invalid OAuth2 token received, no scope claim found but expected: '%s'", String.join(" ", oauth2Config.scopes()));
-            emitAuthenticationFailureAuditEvent(service, configuration, AuthenticationFailureAuditEvent.REASON_MISSING_SCOPE, Response.Status.FORBIDDEN.getStatusCode(), ctx);
+            logger.warnf("Invalid OAuth2 token received, no scope claim found but expected: '%s'",
+                  String.join(" ", oauth2Config.scopes()));
+            emitAuthenticationFailureAuditEvent(service, configuration,
+                  AuthenticationFailureAuditEvent.REASON_MISSING_SCOPE, Response.Status.FORBIDDEN.getStatusCode(), ctx);
             ctx.abortWith(Response.status(Response.Status.FORBIDDEN).build());
             return;
          }
          for (String expectedScope : oauth2Config.scopes()) {
             if (!tokenScopes.contains(expectedScope)) {
-               logger.warnf("Invalid OAuth2 token received, scope claim does not contain expected scope: '%s'", expectedScope);
-               emitAuthenticationFailureAuditEvent(service, configuration, AuthenticationFailureAuditEvent.REASON_MISSING_SCOPE, Response.Status.FORBIDDEN.getStatusCode(), ctx);
+               logger.warnf("Invalid OAuth2 token received, scope claim does not contain expected scope: '%s'",
+                     expectedScope);
+               emitAuthenticationFailureAuditEvent(service, configuration,
+                     AuthenticationFailureAuditEvent.REASON_MISSING_SCOPE, Response.Status.FORBIDDEN.getStatusCode(),
+                     ctx);
                ctx.abortWith(Response.status(Response.Status.FORBIDDEN).build());
                return;
             }
          }
       }
 
-      // Store authenticated user ID (JWT subject) and issuer in request context for downstream
+      // Audience validation
+      if (!oauth2Config.disableAudienceValidation()) {
+         List<String> tokenAudiences = claimsSet.getAudience();
+         if (tokenAudiences == null || tokenAudiences.isEmpty()) {
+            // Already handled by requiredClaims check in jwtProcessor, but for safety:
+            logger.warnf("Invalid OAuth2 token received, missing audience claim");
+            emitAuthenticationFailureAuditEvent(service, configuration,
+                  AuthenticationFailureAuditEvent.REASON_INVALID_TOKEN, Response.Status.UNAUTHORIZED.getStatusCode(),
+                  ctx);
+            ctx.abortWith(Response.status(Response.Status.UNAUTHORIZED).build());
+            return;
+         }
+
+         boolean audienceMatched = false;
+         String requestPath = ctx.getUriInfo().getPath();
+
+         // 1. Check against dynamic FQDN paths
+         for (String fqdn : fqdns) {
+            String expectedAudience = WebUtils.getHTTPScheme(fqdn) + fqdn + requestPath;
+            if (tokenAudiences.contains(expectedAudience)) {
+               audienceMatched = true;
+               break;
+            }
+         }
+
+         // 2. Check against static audiences if configured
+         if (!audienceMatched && oauth2Config.staticAudiences() != null) {
+            for (String staticAudience : oauth2Config.staticAudiences()) {
+               if (tokenAudiences.contains(staticAudience)) {
+                  audienceMatched = true;
+                  break;
+               }
+            }
+         }
+
+         if (!audienceMatched) {
+            logger.warnf(
+                  "Invalid OAuth2 token received, audience claim does not match canonical exposition URI nor any static audience");
+            emitAuthenticationFailureAuditEvent(service, configuration,
+                  AuthenticationFailureAuditEvent.REASON_FORBIDDEN_AUDIENCE, Response.Status.FORBIDDEN.getStatusCode(),
+                  ctx);
+            ctx.abortWith(Response.status(Response.Status.FORBIDDEN).build());
+            return;
+         }
+      }
+
+      // Store authenticated user ID (JWT subject) and issuer in request context for
+      // downstream
       // audit use and stateless user-secret keying (iss + sub).
       String subject = claimsSet.getSubject();
       if (subject != null) {
@@ -355,7 +444,10 @@ public class SecureEndpointFilter implements ContainerRequestFilter {
       return challenge.toString();
    }
 
-   /** Default JOSE verifies allows only exact match on issuers. This verifier allows multiple issuers. */
+   /**
+    * Default JOSE verifies allows only exact match on issuers. This verifier
+    * allows multiple issuers.
+    */
    static class MultipleIssuerClaimsVerifier extends DefaultJWTClaimsVerifier<SecurityContext> {
       private final List<String> expectedIssuers;
 
@@ -376,20 +468,23 @@ public class SecureEndpointFilter implements ContainerRequestFilter {
    }
 
    /**
-    * Emit an audit event for authentication failure if audit is enabled on the configuration.
+    * Emit an audit event for authentication failure if audit is enabled on the
+    * configuration.
     */
    private void emitAuthenticationFailureAuditEvent(ServiceEntry service, ConfigurationEntry configuration,
-                                                    String reason, int httpStatus, ContainerRequestContext ctx) {
+         String reason, int httpStatus, ContainerRequestContext ctx) {
       if (!configuration.audit()) {
          return;
       }
 
-      // Capture trace context now — the span is bound to the current thread and won't be
+      // Capture trace context now — the span is bound to the current thread and won't
+      // be
       // available on the virtual thread used for async emission.
       Span currentSpan = Span.current();
       String traceId = currentSpan.getSpanContext().isValid() ? currentSpan.getSpanContext().getTraceId() : null;
 
-      // Extract source IP (best effort from X-Forwarded-For, X-Real-IP, or remote address).
+      // Extract source IP (best effort from X-Forwarded-For, X-Real-IP, or remote
+      // address).
       String sourceIp = ctx.getHeaderString("X-Forwarded-For");
       if (sourceIp == null) {
          sourceIp = ctx.getHeaderString("X-Real-IP");
@@ -404,8 +499,7 @@ public class SecureEndpointFilter implements ContainerRequestFilter {
       Thread.startVirtualThread(() -> {
          AuthenticationFailureAuditEvent event = new AuthenticationFailureAuditEvent(
                reason, service.id(), service.name(), service.version(), service.organizationId(),
-               finalSourceIp, httpStatus, traceId
-         );
+               finalSourceIp, httpStatus, traceId);
          auditLogger.logAuthFailure(event);
       });
    }

--- a/proxy/src/main/java/io/reshapr/proxy/security/SecureEndpointFilter.java
+++ b/proxy/src/main/java/io/reshapr/proxy/security/SecureEndpointFilter.java
@@ -22,6 +22,7 @@ import io.reshapr.proxy.registry.ExpositionEntry;
 import io.reshapr.proxy.registry.GatewayRegistry;
 import io.reshapr.proxy.registry.OAuth2ConfigurationEntry;
 import io.reshapr.proxy.registry.ServiceEntry;
+import io.reshapr.proxy.security.SecureEndpointFilter.MultipleIssuerClaimsVerifier;
 
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.JOSEObjectType;
@@ -60,11 +61,8 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
- * SecureEndpointFilter is a JAX-RS filter that applies security checks to
- * incoming requests.
- * The filter can be used to enforce security policies, such as authentication
- * and authorization.
- * 
+ * SecureEndpointFilter is a JAX-RS filter that applies security checks to incoming requests.
+ * The filter can be used to enforce security policies, such as authentication and authorization.
  * @author laurent
  */
 @Provider
@@ -80,10 +78,7 @@ public class SecureEndpointFilter implements ContainerRequestFilter {
    /** Request context property key for the authenticated user ID. */
    public static final String USER_ID_PROPERTY = "reshapr.auth.userId";
 
-   /**
-    * Request context property key for the authenticated token issuer (JWT
-    * {@code iss} claim).
-    */
+   /** Request context property key for the authenticated token issuer (JWT {@code iss} claim). */
    public static final String ISSUER_PROPERTY = "reshapr.auth.issuer";
 
    private static final Set<JWSAlgorithm> JWS_SUPPORTED_ALGORITHMS = Set.of(
@@ -92,17 +87,15 @@ public class SecureEndpointFilter implements ContainerRequestFilter {
          JWSAlgorithm.RS512,
          JWSAlgorithm.PS256,
          JWSAlgorithm.PS384,
-         JWSAlgorithm.PS512);
+         JWSAlgorithm.PS512
+   );
    private static final Set<String> JWT_VERIFIED_CLAIMS = Set.of(
          JWTClaimNames.SUBJECT,
          JWTClaimNames.ISSUED_AT,
          JWTClaimNames.EXPIRATION_TIME
    );
 
-   /*
-    * Cache of JWKSource instances keyed by JWK Set URL to avoid reloading keys for
-    * each request.
-    */
+   /* Cache of JWKSource instances keyed by JWK Set URL to avoid reloading keys for each request. */
    private final ConcurrentHashMap<String, JWKSource<SecurityContext>> jwkSources = new ConcurrentHashMap<>();
 
    private final GatewayRegistry gatewayRegistry;
@@ -138,8 +131,7 @@ public class SecureEndpointFilter implements ContainerRequestFilter {
             // 2 segments: /mcp/{organizationId}/{expositionName}
             exposition = gatewayRegistry.getExpositionByName(parts[0], parts[1]);
          } else if (parts.length == 3) {
-            // 3 segments (legacy): /mcp/{organizationId}/{service}/{version} -> elected
-            // exposition.
+            // 3 segments (legacy): /mcp/{organizationId}/{service}/{version} -> elected exposition.
             // If serviceName was encoded with '+' instead of '%20', remove them.
             if (parts[1].contains("+")) {
                parts[1] = parts[1].replace('+', ' ');
@@ -173,34 +165,27 @@ public class SecureEndpointFilter implements ContainerRequestFilter {
    }
 
    private boolean isSecuredWithOAuth2(ConfigurationEntry configuration) {
-      return (configuration.oauth2Configuration() != null
-            && !configuration.oauth2Configuration().authorizationServers().isEmpty());
+      return (configuration.oauth2Configuration() != null && !configuration.oauth2Configuration().authorizationServers().isEmpty());
    }
 
-   private void checkAPIKeyValidity(ServiceEntry service, ConfigurationEntry configuration,
-         ContainerRequestContext ctx) {
+   private void checkAPIKeyValidity(ServiceEntry service, ConfigurationEntry configuration, ContainerRequestContext ctx) {
       // Check for API key in headers.
       String apiKey = ctx.getHeaderString(API_KEY_HEADER);
       boolean valid = configuration.apiKey() != null && configuration.apiKey().equals(apiKey);
       if (!valid) {
          logger.warnf("Invalid or missing API key for configuration with ID: '%s'", configuration.id());
-         emitAuthenticationFailureAuditEvent(service, configuration,
-               AuthenticationFailureAuditEvent.REASON_INVALID_API_KEY, Response.Status.UNAUTHORIZED.getStatusCode(),
-               ctx);
+         emitAuthenticationFailureAuditEvent(service, configuration, AuthenticationFailureAuditEvent.REASON_INVALID_API_KEY, Response.Status.UNAUTHORIZED.getStatusCode(), ctx);
          ctx.abortWith(Response.status(Response.Status.UNAUTHORIZED).build());
       }
    }
 
-   private void checkOAuth2Validity(ServiceEntry service, ConfigurationEntry configuration,
-         ContainerRequestContext ctx) {
+   private void checkOAuth2Validity(ServiceEntry service, ConfigurationEntry configuration, ContainerRequestContext ctx) {
       String fqdnScheme = WebUtils.getHTTPScheme(fqdns.getFirst());
       String authorizationHeader = ctx.getHeaderString(HttpHeaders.AUTHORIZATION);
 
       if (authorizationHeader == null || !authorizationHeader.startsWith("Bearer ")) {
          logger.warnf("Missing or invalid Authorization header for configuration with ID: '%s'", configuration.id());
-         emitAuthenticationFailureAuditEvent(service, configuration,
-               AuthenticationFailureAuditEvent.REASON_MISSING_BEARER, Response.Status.UNAUTHORIZED.getStatusCode(),
-               ctx);
+         emitAuthenticationFailureAuditEvent(service, configuration, AuthenticationFailureAuditEvent.REASON_MISSING_BEARER, Response.Status.UNAUTHORIZED.getStatusCode(), ctx);
          logger.warnf("Redirecting to '%s'", fqdnScheme
                + fqdns.getFirst() + "/.well-known/oauth-protected-resource" + ctx.getUriInfo().getPath());
          ctx.abortWith(Response.status(Response.Status.UNAUTHORIZED)
@@ -241,8 +226,7 @@ public class SecureEndpointFilter implements ContainerRequestFilter {
       }
    }
 
-   private JWTClaimsSet parseAndVerifyToken(ServiceEntry service, ConfigurationEntry configuration,
-         ContainerRequestContext ctx, String token) {
+   private JWTClaimsSet parseAndVerifyToken(ServiceEntry service, ConfigurationEntry configuration, ContainerRequestContext ctx, String token) {
       final OAuth2ConfigurationEntry oauth2Config = configuration.oauth2Configuration();
 
       // Create a JWK source that retrieves the public keys from the JWK Set URL.
@@ -287,25 +271,21 @@ public class SecureEndpointFilter implements ContainerRequestFilter {
          return jwtProcessor.process(token, null);
       } catch (ParseException e) {
          logger.warnf("Malformed OAuth2 token received: %s", e.getMessage());
-         emitAuthenticationFailureAuditEvent(service, configuration,
-               AuthenticationFailureAuditEvent.REASON_MALFORMED_TOKEN, Response.Status.UNAUTHORIZED.getStatusCode(),
-               ctx);
+         emitAuthenticationFailureAuditEvent(service, configuration, AuthenticationFailureAuditEvent.REASON_MALFORMED_TOKEN, Response.Status.UNAUTHORIZED.getStatusCode(), ctx);
          ctx.abortWith(Response.status(Response.Status.UNAUTHORIZED)
                .header(HttpHeaders.WWW_AUTHENTICATE, bearerChallenge(ctx, "invalid_token"))
                .build());
          return null;
       } catch (BadJOSEException e) {
          logger.warnf("Invalid OAuth2 token received: %s", e.getMessage());
-         emitAuthenticationFailureAuditEvent(service, configuration,
-               AuthenticationFailureAuditEvent.REASON_INVALID_TOKEN, Response.Status.UNAUTHORIZED.getStatusCode(), ctx);
+         emitAuthenticationFailureAuditEvent(service, configuration, AuthenticationFailureAuditEvent.REASON_INVALID_TOKEN, Response.Status.UNAUTHORIZED.getStatusCode(), ctx);
          ctx.abortWith(Response.status(Response.Status.UNAUTHORIZED)
                .header(HttpHeaders.WWW_AUTHENTICATE, bearerChallenge(ctx, "invalid_token"))
                .build());
          return null;
       } catch (JOSEException e) {
          logger.warnf("Unable to verify OAuth2 token: %s", e.getMessage());
-         emitAuthenticationFailureAuditEvent(service, configuration,
-               AuthenticationFailureAuditEvent.REASON_INVALID_TOKEN, Response.Status.UNAUTHORIZED.getStatusCode(), ctx);
+         emitAuthenticationFailureAuditEvent(service, configuration, AuthenticationFailureAuditEvent.REASON_INVALID_TOKEN, Response.Status.UNAUTHORIZED.getStatusCode(), ctx);
          ctx.abortWith(Response.status(Response.Status.UNAUTHORIZED)
                .header(HttpHeaders.WWW_AUTHENTICATE, bearerChallenge(ctx, null))
                .build());
@@ -313,47 +293,39 @@ public class SecureEndpointFilter implements ContainerRequestFilter {
       }
    }
 
+   private boolean validateResourceClaim(ServiceEntry service, ConfigurationEntry configuration, ContainerRequestContext ctx, JWTClaimsSet claimsSet, String fqdnScheme) {
       // Now check the claimsSet for resource as per
       // https://modelcontextprotocol.io/specification/2025-06-18/basic/authorization#token-handling
       try {
          String resource = claimsSet.getClaimAsString("resource");
-         if (resource != null
-               && !resource.equalsIgnoreCase(fqdnScheme + fqdns.getFirst() + ctx.getUriInfo().getPath())) {
-            logger.warnf("Invalid OAuth2 token received, resource claim does not match '%s'",
-                  fqdnScheme + fqdns.getFirst() + ctx.getUriInfo().getPath());
-            emitAuthenticationFailureAuditEvent(service, configuration,
-                  AuthenticationFailureAuditEvent.REASON_FORBIDDEN_RESOURCE, Response.Status.FORBIDDEN.getStatusCode(),
-                  ctx);
+         if (resource != null && !resource.equalsIgnoreCase(fqdnScheme + fqdns.getFirst() + ctx.getUriInfo().getPath())) {
+            logger.warnf("Invalid OAuth2 token received, resource claim does not match '%s'", fqdnScheme + fqdns.getFirst() + ctx.getUriInfo().getPath());
+            emitAuthenticationFailureAuditEvent(service, configuration, AuthenticationFailureAuditEvent.REASON_FORBIDDEN_RESOURCE, Response.Status.FORBIDDEN.getStatusCode(), ctx);
             ctx.abortWith(Response.status(Response.Status.FORBIDDEN).build());
             return false;
          }
       } catch (ParseException pe) {
          logger.warnf("Bad OAuth2 token received, resource claim cannot be parsed as String", pe);
-         emitAuthenticationFailureAuditEvent(service, configuration,
-               AuthenticationFailureAuditEvent.REASON_MALFORMED_TOKEN, Response.Status.UNAUTHORIZED.getStatusCode(),
-               ctx);
+         emitAuthenticationFailureAuditEvent(service, configuration, AuthenticationFailureAuditEvent.REASON_MALFORMED_TOKEN, Response.Status.UNAUTHORIZED.getStatusCode(), ctx);
          ctx.abortWith(Response.status(Response.Status.UNAUTHORIZED).build());
          return false;
       }
       return true;
    }
 
+   private boolean validateServiceIdClaim(ServiceEntry service, ConfigurationEntry configuration, ContainerRequestContext ctx, JWTClaimsSet claimsSet) {
       // If issued by the Reshapr internal IDP, we can also check the serviceID claim.
       try {
          String serviceID = claimsSet.getClaimAsString("serviceId");
          if (serviceID != null && !serviceID.equals(service.id())) {
             logger.warnf("Invalid OAuth2 token received, serviceId claim does not match service ID '%s'", service.id());
-            emitAuthenticationFailureAuditEvent(service, configuration,
-                  AuthenticationFailureAuditEvent.REASON_FORBIDDEN_SERVICE, Response.Status.FORBIDDEN.getStatusCode(),
-                  ctx);
+            emitAuthenticationFailureAuditEvent(service, configuration, AuthenticationFailureAuditEvent.REASON_FORBIDDEN_SERVICE, Response.Status.FORBIDDEN.getStatusCode(), ctx);
             ctx.abortWith(Response.status(Response.Status.FORBIDDEN).build());
             return false;
          }
       } catch (ParseException pe) {
          logger.warnf("Bad OAuth2 token received, serviceId claim cannot be parsed as String", pe);
-         emitAuthenticationFailureAuditEvent(service, configuration,
-               AuthenticationFailureAuditEvent.REASON_MALFORMED_TOKEN, Response.Status.UNAUTHORIZED.getStatusCode(),
-               ctx);
+         emitAuthenticationFailureAuditEvent(service, configuration, AuthenticationFailureAuditEvent.REASON_MALFORMED_TOKEN, Response.Status.UNAUTHORIZED.getStatusCode(), ctx);
          ctx.abortWith(Response.status(Response.Status.UNAUTHORIZED).build());
          return false;
       }
@@ -381,29 +353,23 @@ public class SecureEndpointFilter implements ContainerRequestFilter {
             }
          }
       } catch (ParseException pe) {
+         // Malformed token.
          logger.warnf("Bad OAuth2 token received, scope claim cannot be parsed as String or List<String>", pe);
-         emitAuthenticationFailureAuditEvent(service, configuration,
-               AuthenticationFailureAuditEvent.REASON_MALFORMED_TOKEN, Response.Status.UNAUTHORIZED.getStatusCode(),
-               ctx);
+         emitAuthenticationFailureAuditEvent(service, configuration, AuthenticationFailureAuditEvent.REASON_MALFORMED_TOKEN, Response.Status.UNAUTHORIZED.getStatusCode(), ctx);
          ctx.abortWith(Response.status(Response.Status.UNAUTHORIZED).build());
          return false;
       }
 
       if (tokenScopes == null || tokenScopes.isEmpty()) {
-         logger.warnf("Invalid OAuth2 token received, no scope claim found but expected: '%s'",
-               String.join(" ", oauth2Config.scopes()));
-         emitAuthenticationFailureAuditEvent(service, configuration,
-               AuthenticationFailureAuditEvent.REASON_MISSING_SCOPE, Response.Status.FORBIDDEN.getStatusCode(), ctx);
+         logger.warnf("Invalid OAuth2 token received, no scope claim found but expected: '%s'", String.join(" ", oauth2Config.scopes()));
+         emitAuthenticationFailureAuditEvent(service, configuration, AuthenticationFailureAuditEvent.REASON_MISSING_SCOPE, Response.Status.FORBIDDEN.getStatusCode(), ctx);
          ctx.abortWith(Response.status(Response.Status.FORBIDDEN).build());
          return false;
       }
       for (String expectedScope : oauth2Config.scopes()) {
          if (!tokenScopes.contains(expectedScope)) {
-            logger.warnf("Invalid OAuth2 token received, scope claim does not contain expected scope: '%s'",
-                  expectedScope);
-            emitAuthenticationFailureAuditEvent(service, configuration,
-                  AuthenticationFailureAuditEvent.REASON_MISSING_SCOPE, Response.Status.FORBIDDEN.getStatusCode(),
-                  ctx);
+            logger.warnf("Invalid OAuth2 token received, scope claim does not contain expected scope: '%s'", expectedScope);
+            emitAuthenticationFailureAuditEvent(service, configuration, AuthenticationFailureAuditEvent.REASON_MISSING_SCOPE, Response.Status.FORBIDDEN.getStatusCode(), ctx);
             ctx.abortWith(Response.status(Response.Status.FORBIDDEN).build());
             return false;
          }
@@ -419,9 +385,7 @@ public class SecureEndpointFilter implements ContainerRequestFilter {
       List<String> tokenAudiences = claimsSet.getAudience();
       if (tokenAudiences == null || tokenAudiences.isEmpty()) {
          logger.warnf("Invalid OAuth2 token received, missing audience claim");
-         emitAuthenticationFailureAuditEvent(service, configuration,
-               AuthenticationFailureAuditEvent.REASON_INVALID_TOKEN, Response.Status.UNAUTHORIZED.getStatusCode(),
-               ctx);
+         emitAuthenticationFailureAuditEvent(service, configuration, AuthenticationFailureAuditEvent.REASON_INVALID_TOKEN, Response.Status.UNAUTHORIZED.getStatusCode(), ctx);
          ctx.abortWith(Response.status(Response.Status.UNAUTHORIZED).build());
          return false;
       }
@@ -449,11 +413,8 @@ public class SecureEndpointFilter implements ContainerRequestFilter {
       }
 
       if (!audienceMatched) {
-         logger.warnf(
-               "Invalid OAuth2 token received, audience claim does not match canonical exposition URI nor any static audience");
-         emitAuthenticationFailureAuditEvent(service, configuration,
-               AuthenticationFailureAuditEvent.REASON_FORBIDDEN_AUDIENCE, Response.Status.FORBIDDEN.getStatusCode(),
-               ctx);
+         logger.warnf("Invalid OAuth2 token received, audience claim does not match canonical exposition URI nor any static audience");
+         emitAuthenticationFailureAuditEvent(service, configuration, AuthenticationFailureAuditEvent.REASON_FORBIDDEN_AUDIENCE, Response.Status.FORBIDDEN.getStatusCode(), ctx);
          ctx.abortWith(Response.status(Response.Status.FORBIDDEN).build());
          return false;
       }
@@ -472,10 +433,7 @@ public class SecureEndpointFilter implements ContainerRequestFilter {
       return challenge.toString();
    }
 
-   /**
-    * Default JOSE verifies allows only exact match on issuers. This verifier
-    * allows multiple issuers.
-    */
+   /** Default JOSE verifies allows only exact match on issuers. This verifier allows multiple issuers. */
    static class MultipleIssuerClaimsVerifier extends DefaultJWTClaimsVerifier<SecurityContext> {
       private final List<String> expectedIssuers;
 
@@ -496,23 +454,19 @@ public class SecureEndpointFilter implements ContainerRequestFilter {
    }
 
    /**
-    * Emit an audit event for authentication failure if audit is enabled on the
-    * configuration.
+    * Emit an audit event for authentication failure if audit is enabled on the configuration.
     */
-   private void emitAuthenticationFailureAuditEvent(ServiceEntry service, ConfigurationEntry configuration,
-         String reason, int httpStatus, ContainerRequestContext ctx) {
+   private void emitAuthenticationFailureAuditEvent(ServiceEntry service, ConfigurationEntry configuration, String reason, int httpStatus, ContainerRequestContext ctx) {
       if (!configuration.audit()) {
          return;
       }
 
-      // Capture trace context now — the span is bound to the current thread and won't
-      // be
+      // Capture trace context now — the span is bound to the current thread and won't be
       // available on the virtual thread used for async emission.
       Span currentSpan = Span.current();
       String traceId = currentSpan.getSpanContext().isValid() ? currentSpan.getSpanContext().getTraceId() : null;
 
-      // Extract source IP (best effort from X-Forwarded-For, X-Real-IP, or remote
-      // address).
+      // Extract source IP (best effort from X-Forwarded-For, X-Real-IP, or remote address).
       String sourceIp = ctx.getHeaderString("X-Forwarded-For");
       if (sourceIp == null) {
          sourceIp = ctx.getHeaderString("X-Real-IP");
@@ -527,7 +481,8 @@ public class SecureEndpointFilter implements ContainerRequestFilter {
       Thread.startVirtualThread(() -> {
          AuthenticationFailureAuditEvent event = new AuthenticationFailureAuditEvent(
                reason, service.id(), service.name(), service.version(), service.organizationId(),
-               finalSourceIp, httpStatus, traceId);
+               finalSourceIp, httpStatus, traceId
+         );
          auditLogger.logAuthFailure(event);
       });
    }

--- a/proxy/src/test/java/io/reshapr/proxy/security/SecureEndpointFilterTest.java
+++ b/proxy/src/test/java/io/reshapr/proxy/security/SecureEndpointFilterTest.java
@@ -157,7 +157,7 @@ class SecureEndpointFilterTest {
    }
 
    private void registerOAuth2Exposition(String expositionId, List<String> scopes, String jwksSetUri, boolean audit) {
-      OAuth2ConfigurationEntry oauth2 = new OAuth2ConfigurationEntry(List.of(ISSUER), jwksSetUri, scopes);
+      OAuth2ConfigurationEntry oauth2 = new OAuth2ConfigurationEntry(List.of(ISSUER), jwksSetUri, scopes, null, false);
       ConfigurationEntry configuration = new ConfigurationEntry("conf-" + expositionId, "conf", "http://backend",
             30000L, List.of(), List.of(), null, oauth2, null, audit);
       ServiceEntry service = new ServiceEntry("svc1", "org1", "Test Service", "1.0", "REST", List.of());
@@ -194,7 +194,8 @@ class SecureEndpointFilterTest {
             .issuer(ISSUER)
             .issueTime(Date.from(now.minusSeconds(10)))
             .expirationTime(Date.from(now.plusSeconds(300)))
-            .jwtID(UUID.randomUUID().toString());
+            .jwtID(UUID.randomUUID().toString())
+            .audience(CANONICAL_RESOURCE);
       builder = customizer.apply(builder);
 
       SignedJWT jwt = new SignedJWT(
@@ -446,7 +447,7 @@ class SecureEndpointFilterTest {
          filter.filter(ctx1);
          assertNotAborted(ctx1);
 
-         ContainerRequestContext ctx2 = mcpRequest("/mcp/exp2", "Bearer " + validToken());
+         ContainerRequestContext ctx2 = mcpRequest("/mcp/exp2", "Bearer " + token(JOSEObjectType.JWT, b -> b.audience("http://localhost:7777/mcp/exp2")));
          filter.filter(ctx2);
          assertNotAborted(ctx2);
 
@@ -572,8 +573,6 @@ class SecureEndpointFilterTest {
       }
 
       @Test
-      @Disabled("Future MCP MUST: validate the standard aud claim (RFC 8707/9068) against the canonical "
-            + "resource URI — a token minted for another API of the same issuer must be rejected")
       @DisplayName("aud claim bound to another resource -> rejected")
       void mismatchedAudienceIsRejected() throws Exception {
          registerOAuth2Exposition(null);
@@ -588,7 +587,6 @@ class SecureEndpointFilterTest {
       }
 
       @Test
-      @Disabled("Future MCP MUST: aud claim matching the canonical resource URI is accepted")
       @DisplayName("aud claim matching the canonical exposition URI is accepted")
       void matchingAudienceIsAccepted() throws Exception {
          registerOAuth2Exposition(null);


### PR DESCRIPTION
fixes #388 

```text
[INFO] Running Audience and resource binding (MCP MUST)
2026-09-03 12:50:02,934 WARN  [io.reshapr.proxy.security.SecureEndpointFilter] (main) Invalid OAuth2 token received, resource claim does not match 'http://localhost:7777/mcp/exp1'
2026-09-03 12:50:02,963 WARN  [io.reshapr.proxy.security.SecureEndpointFilter] (main) Invalid OAuth2 token received, audience claim does not match canonical exposition URI nor any static audience
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.069 s -- in Audience and resource binding (MCP MUST)

```