### PR TITLE
tests: improve control-plane test coverage

### DIFF
--- a/.github/workflows/build-verify.yml
+++ b/.github/workflows/build-verify.yml
@@ -42,8 +42,8 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: jacoco-report
-          path: target/site/jacoco/
+          name: jacoco-aggregate-report
+          path: e2e-tests/target/site/jacoco-aggregate/
           retention-days: 14
 
       - id: set-environment

--- a/.github/workflows/build-verify.yml
+++ b/.github/workflows/build-verify.yml
@@ -38,6 +38,14 @@ jobs:
       - name: Build Java components
         run: mvn -B -q clean install
 
+      - name: Upload JaCoCo Coverage Report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: jacoco-report
+          path: target/site/jacoco/
+          retention-days: 14
+
       - id: set-environment
         name: Set environment for branch
         run: |

--- a/control-plane/pom.xml
+++ b/control-plane/pom.xml
@@ -161,6 +161,16 @@
       <artifactId>rest-assured</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-test-security</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-test-security-jwt</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/control-plane/pom.xml
+++ b/control-plane/pom.xml
@@ -157,6 +157,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-junit5-mockito</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>io.rest-assured</groupId>
       <artifactId>rest-assured</artifactId>
       <scope>test</scope>

--- a/control-plane/src/test/java/io/reshapr/ctrl/artifacts/GraphQLImporterTest.java
+++ b/control-plane/src/test/java/io/reshapr/ctrl/artifacts/GraphQLImporterTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright The Reshapr Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.reshapr.ctrl.artifacts;
+
+import io.reshapr.ctrl.model.Artifact;
+import io.reshapr.ctrl.model.Service;
+import io.reshapr.ctrl.model.ServiceType;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * @author vaishnav
+ */
+public class GraphQLImporterTest {
+
+    @Test
+    public void testGraphQLImporter() throws Exception {
+        String path = new File("src/test/resources/io/reshapr/ctrl/artifacts/schema.graphql").getAbsolutePath();
+        GraphQLImporter importer = new GraphQLImporter(path);
+        
+        importer.setServiceName("My GraphQL API");
+        importer.setServiceVersion("1.0.0");
+
+        List<Service> services = importer.getServiceDefinitions();
+        assertNotNull(services);
+        assertEquals(1, services.size());
+        
+        Service service = services.get(0);
+        assertEquals("My GraphQL API", service.name);
+        assertEquals("1.0.0", service.version);
+        assertEquals(ServiceType.GRAPHQL, service.type);
+        assertEquals(3, service.operations.size());
+
+        List<Artifact> artifacts = importer.getArtifactDefinitions(service);
+        assertNotNull(artifacts);
+        assertEquals(1, artifacts.size());
+        assertEquals("My GraphQL API-1.0.0.graphql", artifacts.get(0).name);
+    }
+
+    @Test
+    public void testGraphQLImporterMissingName() throws Exception {
+        String path = new File("src/test/resources/io/reshapr/ctrl/artifacts/schema.graphql").getAbsolutePath();
+        GraphQLImporter importer = new GraphQLImporter(path);
+        
+        assertThrows(ArtifactImportException.class, importer::getServiceDefinitions);
+    }
+}

--- a/control-plane/src/test/java/io/reshapr/ctrl/artifacts/OpenAPIImporterTest.java
+++ b/control-plane/src/test/java/io/reshapr/ctrl/artifacts/OpenAPIImporterTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright The Reshapr Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.reshapr.ctrl.artifacts;
+
+import io.reshapr.ctrl.model.Artifact;
+import io.reshapr.ctrl.model.Service;
+import io.reshapr.ctrl.model.ServiceType;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * @author vaishnav
+ */
+public class OpenAPIImporterTest {
+
+    @Test
+    public void testOpenAPIImporter() throws Exception {
+        String path = new File("src/test/resources/io/reshapr/ctrl/artifacts/openapi.json").getAbsolutePath();
+        OpenAPIImporter importer = new OpenAPIImporter(path, null);
+        
+        List<Service> services = importer.getServiceDefinitions();
+        assertNotNull(services);
+        assertEquals(1, services.size());
+        
+        Service service = services.get(0);
+        assertEquals("My API", service.name);
+        assertEquals("1.0.0", service.version);
+        assertEquals(ServiceType.REST, service.type);
+        assertEquals(3, service.operations.size());
+
+        List<Artifact> artifacts = importer.getArtifactDefinitions(service);
+        assertNotNull(artifacts);
+        assertEquals(1, artifacts.size());
+        assertEquals("My API-1.0.0.json", artifacts.get(0).name);
+    }
+}

--- a/control-plane/src/test/java/io/reshapr/ctrl/rest/admin/OrganizationResourceIT.java
+++ b/control-plane/src/test/java/io/reshapr/ctrl/rest/admin/OrganizationResourceIT.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright The Reshapr Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.reshapr.ctrl.rest.admin;
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+import io.restassured.http.ContentType;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+
+/**
+ * @author vaishnav
+ */
+@QuarkusIntegrationTest
+public class OrganizationResourceIT {
+
+    // Using the default API key configured in application.properties
+    private static final String DEFAULT_API_KEY = "CzBuQ9B0i8qrUQe6WLiDLqR3gv4iCbxvjTJQP0z0CFGQbjgBHPZSusa9d1gZKwwjdoCsJ8ogRwRzc06GipJSjSDkFOy0BSOKvAa2EjU3As9I5UjgizTzxsJAVJIXtdo2xiXHhcry9KeJa0zRhDtGmm8WMujoXrlfj0ChlJKaHZiZsRthd4UHrWkKur9KySXpPFP21H4C0Cq6OgM1rJpvMZ7Jd2ZzeEcd5lKE4PlchHZBVEdu8jYzjQtU50fkOPoR";
+
+    @Test
+    public void testCreateAndGetOrganization() {
+        String uniqueSuffix = UUID.randomUUID().toString().substring(0, 8);
+        String orgName = "integration-org-" + uniqueSuffix;
+
+        // 1. Create a new organization
+        given()
+            .header("x-reshapr-api-key", DEFAULT_API_KEY)
+            .contentType(ContentType.JSON)
+            .body("""
+                {
+                    "name": "%s",
+                    "description": "Integration test organization",
+                    "icon": "fa-building"
+                }
+                """.formatted(orgName))
+        .when()
+            .post("/api/admin/organizations")
+        .then()
+            .statusCode(201)
+            .body("name", is(orgName))
+            .body("description", is("Integration test organization"));
+
+        // 2. Retrieve the organization to verify persistence
+        given()
+            .header("x-reshapr-api-key", DEFAULT_API_KEY)
+        .when()
+            .get("/api/admin/organizations?size=100")
+        .then()
+            .statusCode(200)
+            .body("find { it.name == '" + orgName + "' }", notNullValue())
+            .body("find { it.name == '" + orgName + "' }.description", is("Integration test organization"));
+    }
+
+    @Test
+    public void testUnauthorizedAccess() {
+        given()
+            .header("x-reshapr-api-key", "invalid-api-key")
+            .contentType(ContentType.JSON)
+            .body("""
+                {
+                    "name": "unauthorized-org",
+                    "description": "Should fail",
+                    "icon": "fa-times"
+                }
+                """)
+        .when()
+            .post("/api/admin/organizations")
+        .then()
+            .statusCode(401);
+    }
+}

--- a/control-plane/src/test/java/io/reshapr/ctrl/rest/v1/ArtifactResourceTest.java
+++ b/control-plane/src/test/java/io/reshapr/ctrl/rest/v1/ArtifactResourceTest.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright The Reshapr Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.reshapr.ctrl.rest.v1;
+
+import io.quarkus.hibernate.orm.panache.PanacheQuery;
+import io.reshapr.ctrl.model.Artifact;
+import io.reshapr.ctrl.model.Service;
+import io.reshapr.ctrl.repository.ArtifactRepository;
+import io.reshapr.ctrl.service.ArtifactManagerService;
+import io.reshapr.ctrl.service.DependencyNotFoundException;
+import io.reshapr.ctrl.service.ServiceManagerService;
+
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+/**
+ * @author vaishnav
+ */
+@ExtendWith(MockitoExtension.class)
+public class ArtifactResourceTest {
+
+    @Mock
+    private ServiceManagerService serviceManagerService;
+
+    @Mock
+    private ArtifactManagerService artifactManagerService;
+
+    @Mock
+    private ArtifactRepository artifactRepository;
+
+    @Mock
+    private Mappers v1Mappers;
+
+    @Mock
+    private PanacheQuery<Artifact> mockQuery;
+
+    @Mock
+    private PanacheQuery<ArtifactDTO> mockDtoQuery;
+
+    @Mock
+    private PanacheQuery<ArtifactReferenceDTO> mockRefDtoQuery;
+
+    private ArtifactResource artifactResource;
+
+    @BeforeEach
+    public void setup() {
+        artifactResource = new ArtifactResource(serviceManagerService, artifactManagerService, artifactRepository, v1Mappers);
+    }
+
+    @Test
+    public void testGetArtifactSuccess() {
+        Artifact artifact = new Artifact();
+        ArtifactDTO dto = mock(ArtifactDTO.class);
+        
+        when(artifactRepository.findById("art-1")).thenReturn(artifact);
+        when(v1Mappers.toResource(artifact)).thenReturn(dto);
+
+        Response response = artifactResource.getArtifact("art-1");
+        assertEquals(200, response.getStatus());
+        assertEquals(dto, response.getEntity());
+    }
+
+    @Test
+    public void testGetArtifactNotFound() {
+        when(artifactRepository.findById("art-1")).thenReturn(null);
+
+        Response response = artifactResource.getArtifact("art-1");
+        assertEquals(404, response.getStatus());
+    }
+
+    @Test
+    public void testGetArtifactsByServiceId() {
+        ArtifactDTO dto = mock(ArtifactDTO.class);
+        
+        when(artifactRepository.findByServiceId("svc-1")).thenReturn(mockQuery);
+        when(mockQuery.project(ArtifactDTO.class)).thenReturn(mockDtoQuery);
+        when(mockDtoQuery.list()).thenReturn(List.of(dto));
+
+        List<ArtifactDTO> result = artifactResource.getArtifactsByServiceId("svc-1");
+        assertEquals(1, result.size());
+    }
+
+    @Test
+    public void testGetArtifactReferencesByServiceId() {
+        ArtifactReferenceDTO dto = mock(ArtifactReferenceDTO.class);
+        
+        when(artifactRepository.findByServiceId("svc-1")).thenReturn(mockQuery);
+        when(mockQuery.project(ArtifactReferenceDTO.class)).thenReturn(mockRefDtoQuery);
+        when(mockRefDtoQuery.list()).thenReturn(List.of(dto));
+
+        List<ArtifactReferenceDTO> result = artifactResource.getArtifactReferencesByServiceId("svc-1");
+        assertEquals(1, result.size());
+    }
+
+    @Test
+    public void testGetArtifactDeletionImpactSuccess() throws Exception {
+        io.reshapr.ctrl.service.ArtifactDeletionImpact impact = mock(io.reshapr.ctrl.service.ArtifactDeletionImpact.class);
+        ArtifactDeletionImpactDTO dto = mock(ArtifactDeletionImpactDTO.class);
+
+        when(artifactManagerService.getArtifactDeletionImpact("art-1")).thenReturn(impact);
+        when(v1Mappers.toResource(impact)).thenReturn(dto);
+
+        Response response = artifactResource.getArtifactDeletionImpact("art-1");
+        assertEquals(200, response.getStatus());
+        assertEquals(dto, response.getEntity());
+    }
+
+    @Test
+    public void testGetArtifactDeletionImpactNotFound() throws Exception {
+        when(artifactManagerService.getArtifactDeletionImpact("art-1")).thenThrow(new DependencyNotFoundException("Not found"));
+
+        Response response = artifactResource.getArtifactDeletionImpact("art-1");
+        assertEquals(404, response.getStatus());
+    }
+
+    @Test
+    public void testDeleteArtifactSuccess() throws Exception {
+        io.reshapr.ctrl.service.ArtifactDeletionImpact impact = mock(io.reshapr.ctrl.service.ArtifactDeletionImpact.class);
+        ArtifactDeletionImpactDTO dto = mock(ArtifactDeletionImpactDTO.class);
+
+        when(artifactManagerService.deleteArtifact("art-1")).thenReturn(impact);
+        when(v1Mappers.toResource(impact)).thenReturn(dto);
+
+        Response response = artifactResource.deleteArtifact("art-1");
+        assertEquals(200, response.getStatus());
+        assertEquals(dto, response.getEntity());
+    }
+
+    @Test
+    public void testDeleteArtifactNotFound() throws Exception {
+        when(artifactManagerService.deleteArtifact("art-1")).thenThrow(new DependencyNotFoundException("Not found"));
+
+        Response response = artifactResource.deleteArtifact("art-1");
+        assertEquals(404, response.getStatus());
+    }
+}

--- a/control-plane/src/test/java/io/reshapr/ctrl/rest/v1/ConfigurationPlanResourceTest.java
+++ b/control-plane/src/test/java/io/reshapr/ctrl/rest/v1/ConfigurationPlanResourceTest.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright The Reshapr Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.reshapr.ctrl.rest.v1;
+
+import io.reshapr.ctrl.model.ConfigurationPlan;
+import io.reshapr.ctrl.repository.ConfigurationPlanRepository;
+import io.reshapr.ctrl.service.ConfigurationPlanManagerService;
+import io.reshapr.ctrl.service.DependencyNotFoundException;
+import io.reshapr.ctrl.service.InvalidConfigurationException;
+
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+/**
+ * @author vaishnav
+ */
+@ExtendWith(MockitoExtension.class)
+public class ConfigurationPlanResourceTest {
+
+    @Mock
+    private ConfigurationPlanManagerService managerService;
+
+    @Mock
+    private ConfigurationPlanRepository configurationPlanRepository;
+
+    @Mock
+    private Mappers v1Mappers;
+
+    private ConfigurationPlanResource configurationPlanResource;
+
+    @BeforeEach
+    public void setup() {
+        configurationPlanResource = new ConfigurationPlanResource(managerService, configurationPlanRepository, v1Mappers);
+    }
+
+    @Test
+    public void testGetConfigurationPlans() {
+        ConfigurationPlan plan = new ConfigurationPlan();
+        ConfigurationPlanDTO dto = new ConfigurationPlanDTO();
+        dto.setId("plan-1");
+
+        when(managerService.getConfigurationPlans("svc-1")).thenReturn(List.of(plan));
+        when(v1Mappers.toCPResources(List.of(plan))).thenReturn(List.of(dto));
+
+        List<ConfigurationPlanDTO> result = configurationPlanResource.getConfigurationPlans("svc-1");
+        assertEquals(1, result.size());
+        assertEquals("plan-1", result.get(0).getId());
+    }
+
+    @Test
+    public void testCreateConfigurationPlanSuccess() throws Exception {
+        ConfigurationPlanDTO requestDto = new ConfigurationPlanDTO();
+        requestDto.setServiceId("svc-1");
+        requestDto.setBackendSecretId("backend-1");
+        requestDto.setApiKey("api-key");
+        
+        ConfigurationPlan plan = new ConfigurationPlan();
+        ConfigurationPlan createdPlan = new ConfigurationPlan();
+        createdPlan.apiKey = "new-api-key";
+
+        ConfigurationPlanDTO responseDto = new ConfigurationPlanDTO();
+        responseDto.setId("plan-1");
+
+        when(v1Mappers.fromResource(requestDto)).thenReturn(plan);
+        when(managerService.createConfigurationPlan(eq(plan), eq("svc-1"), eq("backend-1"), anyBoolean())).thenReturn(createdPlan);
+        when(v1Mappers.toResource(createdPlan)).thenReturn(responseDto);
+
+        Response response = configurationPlanResource.createConfigurationPlan(requestDto);
+        assertEquals(201, response.getStatus());
+
+        ConfigurationPlanDTO returnedDto = (ConfigurationPlanDTO) response.getEntity();
+        assertEquals("new-api-key", returnedDto.getApiKey());
+    }
+
+    @Test
+    public void testCreateConfigurationPlanDependencyNotFound() throws Exception {
+        ConfigurationPlanDTO requestDto = new ConfigurationPlanDTO();
+        requestDto.setServiceId("svc-1");
+        requestDto.setBackendSecretId("backend-1");
+        
+        ConfigurationPlan plan = new ConfigurationPlan();
+
+        when(v1Mappers.fromResource(requestDto)).thenReturn(plan);
+        when(managerService.createConfigurationPlan(eq(plan), eq("svc-1"), eq("backend-1"), anyBoolean()))
+                .thenThrow(new DependencyNotFoundException("Not found"));
+
+        Response response = configurationPlanResource.createConfigurationPlan(requestDto);
+        assertEquals(404, response.getStatus());
+    }
+
+    @Test
+    public void testDuplicateConfigurationPlanSuccess() throws Exception {
+        ConfigurationPlan newPlan = new ConfigurationPlan();
+        newPlan.apiKey = "duplicate-api-key";
+        ConfigurationPlanDTO responseDto = new ConfigurationPlanDTO();
+        responseDto.setId("plan-2");
+
+        when(managerService.duplicateConfigurationPlan("plan-1", "New Plan")).thenReturn(newPlan);
+        when(v1Mappers.toResource(newPlan)).thenReturn(responseDto);
+
+        Response response = configurationPlanResource.duplicateConfigurationPlan("plan-1", "New Plan");
+        assertEquals(201, response.getStatus());
+        assertEquals("duplicate-api-key", ((ConfigurationPlanDTO) response.getEntity()).getApiKey());
+    }
+
+    @Test
+    public void testDeleteConfigurationPlanSuccess() {
+        ConfigurationPlan plan = new ConfigurationPlan();
+        when(configurationPlanRepository.findById("plan-1")).thenReturn(plan);
+        doNothing().when(managerService).deleteConfigurationPlan(plan);
+
+        Response response = configurationPlanResource.deleteConfigurationPlan("plan-1");
+        assertEquals(204, response.getStatus());
+        verify(managerService, times(1)).deleteConfigurationPlan(plan);
+    }
+}

--- a/control-plane/src/test/java/io/reshapr/ctrl/rest/v1/ExpositionResourceTest.java
+++ b/control-plane/src/test/java/io/reshapr/ctrl/rest/v1/ExpositionResourceTest.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright The Reshapr Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.reshapr.ctrl.rest.v1;
+
+import io.reshapr.ctrl.model.ActiveExposition;
+import io.reshapr.ctrl.model.Exposition;
+import io.reshapr.ctrl.repository.ExpositionRepository;
+import io.reshapr.ctrl.service.DependencyNotFoundException;
+import io.reshapr.ctrl.service.ExpositionManagerService;
+
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+/**
+ * @author vaishnav
+ */
+@ExtendWith(MockitoExtension.class)
+public class ExpositionResourceTest {
+
+    @Mock
+    private ExpositionManagerService expositionManagerService;
+
+    @Mock
+    private ExpositionRepository expositionRepository;
+
+    @Mock
+    private Mappers v1Mappers;
+
+    private ExpositionResource expositionResource;
+
+    @BeforeEach
+    public void setup() {
+        expositionResource = new ExpositionResource(expositionManagerService, expositionRepository, v1Mappers);
+    }
+
+    @Test
+    public void testCreateExpositionSuccess() throws Exception {
+        ExpositionReferenceDTO requestDto = new ExpositionReferenceDTO(null, null, "My Expo", null, "gg-1", "plan-1");
+        Exposition exposition = new Exposition();
+        ExpositionDTO responseDto = new ExpositionDTO("exp-1", "org-1", "My Expo", null, null, null, null);
+
+        when(expositionManagerService.exposeConfiguration("plan-1", "gg-1", "My Expo")).thenReturn(exposition);
+        when(v1Mappers.toResource(exposition)).thenReturn(responseDto);
+
+        Response response = expositionResource.createExposition(requestDto);
+        assertEquals(201, response.getStatus());
+        assertEquals(responseDto, response.getEntity());
+    }
+
+    @Test
+    public void testCreateExpositionNotFound() throws Exception {
+        ExpositionReferenceDTO requestDto = new ExpositionReferenceDTO(null, null, "My Expo", null, "gg-1", "plan-1");
+
+        when(expositionManagerService.exposeConfiguration("plan-1", "gg-1", "My Expo"))
+                .thenThrow(new DependencyNotFoundException("Plan not found"));
+
+        Response response = expositionResource.createExposition(requestDto);
+        assertEquals(404, response.getStatus());
+    }
+
+    @Test
+    public void testListExpositions() {
+        Exposition exposition = new Exposition();
+        ExpositionDTO dto = new ExpositionDTO("exp-1", "org-1", "My Expo", null, null, null, null);
+
+        when(expositionManagerService.getExpositions("svc-1", "gg-1")).thenReturn(List.of(exposition));
+        when(v1Mappers.toEResources(List.of(exposition))).thenReturn(List.of(dto));
+
+        List<ExpositionDTO> result = expositionResource.listExpositions("svc-1", "gg-1");
+        assertEquals(1, result.size());
+        assertEquals("exp-1", result.get(0).id());
+    }
+
+    @Test
+    public void testListActiveExpositions() {
+        ActiveExposition activeExposition = new ActiveExposition();
+        ActiveExpositionDTO dto = new ActiveExpositionDTO("act-1", "org-1", "My Expo", null, null, null, null);
+
+        when(expositionManagerService.getActiveExpositions()).thenReturn(List.of(activeExposition));
+        when(v1Mappers.toAEResources(List.of(activeExposition))).thenReturn(List.of(dto));
+
+        List<ActiveExpositionDTO> result = expositionResource.listActiveExpositions();
+        assertEquals(1, result.size());
+        assertEquals("act-1", result.get(0).id());
+    }
+
+    @Test
+    public void testGetExpositionSuccess() {
+        Exposition exposition = new Exposition();
+        ExpositionDTO dto = new ExpositionDTO("exp-1", "org-1", "My Expo", null, null, null, null);
+
+        when(expositionManagerService.getExposition("exp-1")).thenReturn(exposition);
+        when(v1Mappers.toResource(exposition)).thenReturn(dto);
+
+        Response response = expositionResource.getExposition("exp-1");
+        assertEquals(200, response.getStatus());
+        assertEquals(dto, response.getEntity());
+    }
+
+    @Test
+    public void testGetExpositionNotFound() {
+        when(expositionManagerService.getExposition("exp-1")).thenReturn(null);
+
+        Response response = expositionResource.getExposition("exp-1");
+        assertEquals(404, response.getStatus());
+    }
+
+    @Test
+    public void testGetActiveExpositionSuccess() {
+        ActiveExposition activeExposition = new ActiveExposition();
+        ActiveExpositionDTO dto = new ActiveExpositionDTO("act-1", "org-1", "My Expo", null, null, null, null);
+
+        when(expositionManagerService.getActiveExposition("act-1")).thenReturn(activeExposition);
+        when(v1Mappers.toResource(activeExposition)).thenReturn(dto);
+
+        Response response = expositionResource.getActiveExposition("act-1");
+        assertEquals(200, response.getStatus());
+        assertEquals(dto, response.getEntity());
+    }
+
+    @Test
+    public void testGetActiveExpositionNotFound() {
+        when(expositionManagerService.getActiveExposition("act-1")).thenReturn(null);
+
+        Response response = expositionResource.getActiveExposition("act-1");
+        assertEquals(404, response.getStatus());
+    }
+
+    @Test
+    public void testDeleteExpositionSuccess() throws Exception {
+        doNothing().when(expositionManagerService).removeExposition("exp-1");
+
+        Response response = expositionResource.deleteExposition("exp-1");
+        assertEquals(204, response.getStatus());
+    }
+
+    @Test
+    public void testDeleteExpositionNotFound() throws Exception {
+        doThrow(new DependencyNotFoundException("Not found")).when(expositionManagerService).removeExposition("exp-1");
+
+        Response response = expositionResource.deleteExposition("exp-1");
+        assertEquals(404, response.getStatus());
+    }
+}

--- a/control-plane/src/test/java/io/reshapr/ctrl/rest/v1/GatewayGroupResourceTest.java
+++ b/control-plane/src/test/java/io/reshapr/ctrl/rest/v1/GatewayGroupResourceTest.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright The Reshapr Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.reshapr.ctrl.rest.v1;
+
+import io.quarkus.security.identity.SecurityIdentity;
+import io.reshapr.ctrl.model.GatewayGroup;
+import io.reshapr.ctrl.repository.GatewayGroupRepository;
+import io.reshapr.ctrl.security.ReshaprTenantResolver;
+import io.reshapr.ctrl.service.GatewayGroupManagerService;
+
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+/**
+ * @author vaishnav
+ */
+@ExtendWith(MockitoExtension.class)
+public class GatewayGroupResourceTest {
+
+    @Mock
+    private GatewayGroupManagerService managerService;
+
+    @Mock
+    private GatewayGroupRepository gatewayGroupRepository;
+
+    @Mock
+    private Mappers v1Mappers;
+
+    @Mock
+    private SecurityIdentity securityIdentity;
+
+    private GatewayGroupResource gatewayGroupResource;
+
+    @BeforeEach
+    public void setup() {
+        gatewayGroupResource = new GatewayGroupResource(managerService, gatewayGroupRepository, v1Mappers);
+        gatewayGroupResource.securityIdentity = securityIdentity;
+    }
+
+    @Test
+    public void testGetGatewayGroupsList() {
+        GatewayGroup gatewayGroup = new GatewayGroup();
+        GatewayGroupDTO dto = new GatewayGroupDTO("gg-1", "org-1", "My Group", null);
+
+        when(managerService.getAvailableGatewayGroups()).thenReturn(List.of(gatewayGroup));
+        when(v1Mappers.toGGResources(List.of(gatewayGroup))).thenReturn(List.of(dto));
+
+        List<GatewayGroupDTO> result = gatewayGroupResource.getGatewayGroups();
+        assertEquals(1, result.size());
+        assertEquals("gg-1", result.get(0).id());
+    }
+
+    @Test
+    public void testGetGatewayGroupByIdSuccess() {
+        GatewayGroup gatewayGroup = new GatewayGroup();
+        GatewayGroupDTO dto = new GatewayGroupDTO("gg-1", "org-1", "My Group", null);
+
+        when(gatewayGroupRepository.findById("gg-1")).thenReturn(gatewayGroup);
+        when(v1Mappers.toResource(gatewayGroup)).thenReturn(dto);
+
+        Response response = gatewayGroupResource.getGatewayGroups("gg-1");
+        assertEquals(200, response.getStatus());
+        assertEquals(dto, response.getEntity());
+    }
+
+    @Test
+    public void testGetGatewayGroupByIdNotFound() {
+        when(gatewayGroupRepository.findById("gg-1")).thenReturn(null);
+
+        Response response = gatewayGroupResource.getGatewayGroups("gg-1");
+        assertEquals(404, response.getStatus());
+    }
+
+    @Test
+    public void testCreateGatewayGroupSuccess() {
+        GatewayGroupDTO requestDto = new GatewayGroupDTO(null, null, "My Group", Map.of("env", "prod"));
+        GatewayGroup gatewayGroup = new GatewayGroup();
+        gatewayGroup.name = "My Group";
+
+        GatewayGroupDTO responseDto = new GatewayGroupDTO("gg-1", "org-1", "My Group", Map.of("env", "prod"));
+
+        when(v1Mappers.fromResource(requestDto)).thenReturn(gatewayGroup);
+        when(securityIdentity.getAttribute(ReshaprTenantResolver.TENANT_ID_CONTEXT_KEY)).thenReturn("org-1");
+        when(v1Mappers.toResource(gatewayGroup)).thenReturn(responseDto);
+
+        Response response = gatewayGroupResource.createGatewayGroup(requestDto);
+        assertEquals(201, response.getStatus());
+        assertEquals(responseDto, response.getEntity());
+        assertEquals("org-1", gatewayGroup.organizationId);
+        
+        verify(gatewayGroupRepository, times(1)).persistAndFlush(gatewayGroup);
+    }
+
+    @Test
+    public void testCreateGatewayGroupUnauthorized() {
+        gatewayGroupResource.securityIdentity = null;
+        GatewayGroupDTO requestDto = new GatewayGroupDTO(null, null, "My Group", null);
+
+        Response response = gatewayGroupResource.createGatewayGroup(requestDto);
+        assertEquals(401, response.getStatus());
+    }
+
+    @Test
+    public void testUpdateGatewayGroupSuccess() {
+        GatewayGroupDTO requestDto = new GatewayGroupDTO("gg-1", "org-1", "Updated Group", Map.of("env", "dev"));
+        GatewayGroup gatewayGroup = new GatewayGroup();
+        gatewayGroup.id = "gg-1";
+        gatewayGroup.name = "Old Group";
+
+        GatewayGroupDTO responseDto = new GatewayGroupDTO("gg-1", "org-1", "Updated Group", Map.of("env", "dev"));
+
+        when(gatewayGroupRepository.findById("gg-1")).thenReturn(gatewayGroup);
+        when(v1Mappers.toResource(gatewayGroup)).thenReturn(responseDto);
+
+        Response response = gatewayGroupResource.updateGatewayGroup("gg-1", requestDto);
+        assertEquals(200, response.getStatus());
+        assertEquals(responseDto, response.getEntity());
+        assertEquals("Updated Group", gatewayGroup.name);
+        assertEquals("dev", gatewayGroup.labels.get("env"));
+
+        verify(gatewayGroupRepository, times(1)).persist(gatewayGroup);
+    }
+
+    @Test
+    public void testUpdateGatewayGroupNotFound() {
+        GatewayGroupDTO requestDto = new GatewayGroupDTO("gg-1", "org-1", "Updated Group", null);
+        when(gatewayGroupRepository.findById("gg-1")).thenReturn(null);
+
+        Response response = gatewayGroupResource.updateGatewayGroup("gg-1", requestDto);
+        assertEquals(404, response.getStatus());
+    }
+
+    @Test
+    public void testDeleteGatewayGroupSuccess() {
+        GatewayGroup gatewayGroup = new GatewayGroup();
+        when(gatewayGroupRepository.findById("gg-1")).thenReturn(gatewayGroup);
+
+        Response response = gatewayGroupResource.deleteGatewayGroup("gg-1");
+        assertEquals(204, response.getStatus());
+
+        verify(gatewayGroupRepository, times(1)).delete(gatewayGroup);
+    }
+
+    @Test
+    public void testDeleteGatewayGroupNotFound() {
+        when(gatewayGroupRepository.findById("gg-1")).thenReturn(null);
+
+        Response response = gatewayGroupResource.deleteGatewayGroup("gg-1");
+        assertEquals(404, response.getStatus());
+    }
+}

--- a/control-plane/src/test/java/io/reshapr/ctrl/rest/v1/GatewayResourceTest.java
+++ b/control-plane/src/test/java/io/reshapr/ctrl/rest/v1/GatewayResourceTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright The Reshapr Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.reshapr.ctrl.rest.v1;
+
+import io.reshapr.ctrl.model.Gateway;
+import io.reshapr.ctrl.service.GatewayManagerService;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author vaishnav
+ */
+@ExtendWith(MockitoExtension.class)
+public class GatewayResourceTest {
+
+    @Mock
+    private GatewayManagerService gatewayManagerService;
+
+    @Mock
+    private Mappers v1Mappers;
+
+    private GatewayResource gatewayResource;
+
+    @BeforeEach
+    public void setup() {
+        gatewayResource = new GatewayResource(gatewayManagerService, v1Mappers);
+    }
+
+    @Test
+    public void testListGateways() {
+        Gateway gateway = new Gateway();
+        gateway.name = "my-gateway";
+
+        GatewayViewDTO dto = new GatewayViewDTO(
+                "gw-1",
+                null,
+                "my-gateway",
+                "1.0.0",
+                null,
+                null,
+                List.of(),
+                null,
+                null
+        );
+
+        when(gatewayManagerService.getActiveGateways()).thenReturn(List.of(gateway));
+        when(v1Mappers.toGWResources(List.of(gateway))).thenReturn(List.of(dto));
+
+        List<GatewayViewDTO> result = gatewayResource.listGateways();
+
+        assertEquals(1, result.size());
+        assertEquals("my-gateway", result.get(0).name());
+    }
+}

--- a/control-plane/src/test/java/io/reshapr/ctrl/rest/v1/SecretResourceTest.java
+++ b/control-plane/src/test/java/io/reshapr/ctrl/rest/v1/SecretResourceTest.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright The Reshapr Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.reshapr.ctrl.rest.v1;
+
+import io.quarkus.panache.common.Page;
+import io.quarkus.panache.common.Sort;
+import io.quarkus.hibernate.orm.panache.PanacheQuery;
+import io.reshapr.ctrl.model.Secret;
+import io.reshapr.ctrl.model.SecretType;
+import io.reshapr.ctrl.repository.SecretRepository;
+
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+/**
+ * @author vaishnav
+ */
+@ExtendWith(MockitoExtension.class)
+public class SecretResourceTest {
+
+    @Mock
+    private SecretRepository secretRepository;
+
+    @Mock
+    private Mappers v1Mappers;
+
+    @Mock
+    private MappersImpl mappersImpl;
+
+    @Mock
+    private PanacheQuery<Secret> mockQuery;
+
+    @Mock
+    private PanacheQuery<SecretReferenceDTO> mockRefQuery;
+
+    private SecretResource secretResource;
+
+    @BeforeEach
+    public void setup() {
+        secretResource = new SecretResource(secretRepository, v1Mappers, mappersImpl);
+    }
+
+    @Test
+    public void testGetSecrets() {
+        Secret secret = new Secret();
+        SecretDTO dto = mock(SecretDTO.class);
+        when(dto.id()).thenReturn("sec-1");
+
+        when(secretRepository.findAll(any(Sort.class))).thenReturn(mockQuery);
+        when(mockQuery.page(any(Page.class))).thenReturn(mockQuery);
+        when(mockQuery.list()).thenReturn(List.of(secret));
+        when(v1Mappers.toResource(secret)).thenReturn(dto);
+
+        List<SecretDTO> result = secretResource.getSecrets(0, 20);
+        assertEquals(1, result.size());
+        assertEquals("sec-1", result.get(0).id());
+    }
+
+    @Test
+    public void testGetSecretReferences() {
+        SecretReferenceDTO dto = mock(SecretReferenceDTO.class);
+        when(dto.id()).thenReturn("sec-1");
+
+        when(secretRepository.findAll(any(Sort.class))).thenReturn(mockQuery);
+        when(mockQuery.page(any(Page.class))).thenReturn(mockQuery);
+        when(mockQuery.project(SecretReferenceDTO.class)).thenReturn(mockRefQuery);
+        when(mockRefQuery.list()).thenReturn(List.of(dto));
+
+        List<SecretReferenceDTO> result = secretResource.getSecretReferences(0, 20);
+        assertEquals(1, result.size());
+        assertEquals("sec-1", result.get(0).id());
+    }
+
+    @Test
+    public void testCreateSecretSuccess() {
+        SecretDTO requestDto = mock(SecretDTO.class);
+        when(requestDto.name()).thenReturn("New Secret");
+        
+        Secret secret = new Secret();
+        SecretDTO responseDto = mock(SecretDTO.class);
+        
+        when(secretRepository.findByName("New Secret")).thenReturn(null);
+        when(v1Mappers.fromResource(requestDto)).thenReturn(secret);
+        doNothing().when(secretRepository).persistAndFlush(secret);
+        when(v1Mappers.toResource(secret)).thenReturn(responseDto);
+
+        Response response = secretResource.createSecret(requestDto);
+        assertEquals(201, response.getStatus());
+        assertEquals(responseDto, response.getEntity());
+    }
+
+    @Test
+    public void testCreateSecretConflict() {
+        SecretDTO requestDto = mock(SecretDTO.class);
+        when(requestDto.name()).thenReturn("Existing Secret");
+        when(secretRepository.findByName("Existing Secret")).thenReturn(new Secret());
+
+        Response response = secretResource.createSecret(requestDto);
+        assertEquals(409, response.getStatus());
+    }
+
+    @Test
+    public void testUpdateSecretSuccess() {
+        SecretDTO requestDto = mock(SecretDTO.class);
+        when(requestDto.password()).thenReturn("new-password");
+        when(requestDto.token()).thenReturn("new-token");
+        Secret existingSecret = new Secret();
+
+        when(secretRepository.findById("sec-1")).thenReturn(existingSecret);
+        when(v1Mappers.toResource(existingSecret)).thenReturn(requestDto);
+
+        Response response = secretResource.updateSecret("sec-1", requestDto);
+        assertEquals(200, response.getStatus());
+        assertEquals(requestDto, response.getEntity());
+    }
+
+    @Test
+    public void testDeleteSecretSuccess() {
+        Secret secret = new Secret();
+        when(secretRepository.findById("sec-1")).thenReturn(secret);
+        doNothing().when(secretRepository).delete(secret);
+
+        Response response = secretResource.deleteSecret("sec-1");
+        assertEquals(204, response.getStatus());
+    }
+
+    @Test
+    public void testDeleteSecretNotFound() {
+        when(secretRepository.findById("sec-1")).thenReturn(null);
+
+        Response response = secretResource.deleteSecret("sec-1");
+        assertEquals(404, response.getStatus());
+    }
+}

--- a/control-plane/src/test/java/io/reshapr/ctrl/rest/v1/ServiceResourceTest.java
+++ b/control-plane/src/test/java/io/reshapr/ctrl/rest/v1/ServiceResourceTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright The Reshapr Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.reshapr.ctrl.rest.v1;
+
+import io.quarkus.panache.common.Page;
+import io.quarkus.panache.common.Sort;
+import io.quarkus.hibernate.orm.panache.PanacheQuery;
+import io.reshapr.ctrl.model.Service;
+import io.reshapr.ctrl.repository.ServiceRepository;
+import io.reshapr.ctrl.service.ServiceManagerService;
+
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+/**
+ * @author vaishnav
+ */
+@ExtendWith(MockitoExtension.class)
+public class ServiceResourceTest {
+
+    @Mock
+    private ServiceManagerService serviceManagerService;
+
+    @Mock
+    private ServiceRepository serviceRepository;
+
+    @Mock
+    private Mappers v1Mappers;
+
+    @Mock
+    private PanacheQuery<Service> mockQuery;
+
+    @Mock
+    private PanacheQuery<ServiceDTO> mockDtoQuery;
+
+    private ServiceResource serviceResource;
+
+    @BeforeEach
+    public void setup() {
+        serviceResource = new ServiceResource(serviceManagerService, serviceRepository, v1Mappers);
+    }
+
+    @Test
+    public void testGetServices() {
+        ServiceDTO dto = mock(ServiceDTO.class);
+        when(dto.id()).thenReturn("svc-1");
+
+        when(serviceRepository.findAll(any(Sort.class))).thenReturn(mockQuery);
+        when(mockQuery.page(any(Page.class))).thenReturn(mockQuery);
+        when(mockQuery.project(ServiceDTO.class)).thenReturn(mockDtoQuery);
+        when(mockDtoQuery.list()).thenReturn(List.of(dto));
+
+        List<ServiceDTO> result = serviceResource.getServices(0, 20);
+        assertEquals(1, result.size());
+        assertEquals("svc-1", result.get(0).id());
+    }
+
+    @Test
+    public void testGetServiceViewSuccess() {
+        Service service = new Service();
+        ServiceViewDTO viewDto = mock(ServiceViewDTO.class);
+
+        when(serviceRepository.findByIdWithOperations("svc-1")).thenReturn(service);
+        when(v1Mappers.toResource(service)).thenReturn(viewDto);
+
+        Response response = serviceResource.getServiceView("svc-1");
+        assertEquals(200, response.getStatus());
+        assertEquals(viewDto, response.getEntity());
+    }
+
+    @Test
+    public void testGetServiceViewNotFound() {
+        when(serviceRepository.findByIdWithOperations("svc-1")).thenReturn(null);
+
+        Response response = serviceResource.getServiceView("svc-1");
+        assertEquals(404, response.getStatus());
+    }
+
+    @Test
+    public void testDeleteServiceSuccess() {
+        when(serviceManagerService.deleteService("svc-1")).thenReturn(true);
+
+        Response response = serviceResource.deleteService("svc-1");
+        assertEquals(204, response.getStatus());
+    }
+
+    @Test
+    public void testDeleteServiceNotFound() {
+        when(serviceManagerService.deleteService("svc-1")).thenReturn(false);
+
+        Response response = serviceResource.deleteService("svc-1");
+        assertEquals(404, response.getStatus());
+    }
+}

--- a/control-plane/src/test/java/io/reshapr/ctrl/rest/v1/TokenResourceTest.java
+++ b/control-plane/src/test/java/io/reshapr/ctrl/rest/v1/TokenResourceTest.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright The Reshapr Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.reshapr.ctrl.rest.v1;
+
+import io.quarkus.security.identity.SecurityIdentity;
+import io.reshapr.ctrl.model.ApiToken;
+import io.reshapr.ctrl.repository.ApiTokenRepository;
+import io.reshapr.ctrl.security.ReshaprTenantResolver;
+import io.reshapr.ctrl.service.DependencyNotFoundException;
+import io.reshapr.ctrl.service.TokenManagerService;
+
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.security.Principal;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+/**
+ * @author vaishnav
+ */
+@ExtendWith(MockitoExtension.class)
+public class TokenResourceTest {
+
+    @Mock
+    private TokenManagerService tokenManagerService;
+
+    @Mock
+    private ApiTokenRepository apiTokenRepository;
+
+    @Mock
+    private Mappers v1Mappers;
+
+    @Mock
+    private SecurityIdentity securityIdentity;
+
+    @Mock
+    private Principal principal;
+
+    private TokenResource tokenResource;
+
+    @BeforeEach
+    public void setup() {
+        tokenResource = new TokenResource(tokenManagerService, apiTokenRepository, v1Mappers);
+        tokenResource.securityIdentity = securityIdentity;
+    }
+
+    @Test
+    public void testGetApiTokens() {
+        ApiToken apiToken = new ApiToken();
+        ApiTokenDTO dto = new ApiTokenDTO();
+        dto.setId("token-1");
+
+        when(securityIdentity.getAttribute(ReshaprTenantResolver.TENANT_ID_CONTEXT_KEY)).thenReturn("org-1");
+        when(tokenManagerService.getApiTokens("org-1")).thenReturn(List.of(apiToken));
+        when(v1Mappers.toATResources(List.of(apiToken))).thenReturn(List.of(dto));
+
+        List<ApiTokenDTO> result = tokenResource.getApiTokens();
+        assertEquals(1, result.size());
+        assertEquals("token-1", result.get(0).getId());
+    }
+
+    @Test
+    public void testCreateApiTokenSuccess() throws Exception {
+        ApiTokenRequestDTO requestDto = new ApiTokenRequestDTO("My Token", ValidityPeriodEnum.THIRTY_DAYS);
+        
+        when(securityIdentity.getPrincipal()).thenReturn(principal);
+        when(principal.getName()).thenReturn("testuser");
+        when(securityIdentity.getAttribute(ReshaprTenantResolver.TENANT_ID_CONTEXT_KEY)).thenReturn("org-1");
+
+        ApiToken createdToken = new ApiToken();
+        createdToken.token = "secret-token-value";
+        ApiTokenDTO responseDto = new ApiTokenDTO();
+        responseDto.setId("token-1");
+
+        when(tokenManagerService.generateApiToken(eq("My Token"), eq("org-1"), eq(30), eq("testuser"))).thenReturn(createdToken);
+        when(v1Mappers.toResource(createdToken)).thenReturn(responseDto);
+
+        Response response = tokenResource.createApiToken(requestDto);
+        assertEquals(201, response.getStatus());
+        
+        ApiTokenDTO returnedDto = (ApiTokenDTO) response.getEntity();
+        assertEquals("secret-token-value", returnedDto.getToken());
+    }
+
+    @Test
+    public void testCreateApiTokenDependencyNotFound() throws Exception {
+        ApiTokenRequestDTO requestDto = new ApiTokenRequestDTO("My Token", ValidityPeriodEnum.THIRTY_DAYS);
+        
+        when(securityIdentity.getPrincipal()).thenReturn(principal);
+        when(principal.getName()).thenReturn("testuser");
+        when(securityIdentity.getAttribute(ReshaprTenantResolver.TENANT_ID_CONTEXT_KEY)).thenReturn("org-1");
+
+        when(tokenManagerService.generateApiToken(anyString(), anyString(), anyInt(), anyString()))
+                .thenThrow(new DependencyNotFoundException("Org not found"));
+
+        Response response = tokenResource.createApiToken(requestDto);
+        assertEquals(500, response.getStatus());
+    }
+
+    @Test
+    public void testDeleteApiTokenSuccess() {
+        ApiToken apiToken = new ApiToken();
+        when(apiTokenRepository.findById("token-1")).thenReturn(apiToken);
+        doNothing().when(tokenManagerService).revokeApiToken(apiToken);
+
+        Response response = tokenResource.deleteApiToken("token-1");
+        assertEquals(204, response.getStatus());
+        verify(tokenManagerService, times(1)).revokeApiToken(apiToken);
+    }
+
+    @Test
+    public void testDeleteApiTokenNotFound() {
+        when(apiTokenRepository.findById("token-1")).thenReturn(null);
+
+        Response response = tokenResource.deleteApiToken("token-1");
+        assertEquals(404, response.getStatus());
+        verify(tokenManagerService, never()).revokeApiToken(any());
+    }
+}

--- a/control-plane/src/test/java/io/reshapr/ctrl/rest/v1/UserProfileResourceTest.java
+++ b/control-plane/src/test/java/io/reshapr/ctrl/rest/v1/UserProfileResourceTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright The Reshapr Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.reshapr.ctrl.rest.v1;
+
+import io.quarkus.security.identity.SecurityIdentity;
+import io.reshapr.ctrl.model.User;
+import io.reshapr.ctrl.repository.UserRepository;
+
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.security.Principal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.*;
+
+/**
+ * @author vaishnav
+ */
+@ExtendWith(MockitoExtension.class)
+public class UserProfileResourceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private Mappers v1Mappers;
+
+    @Mock
+    private SecurityIdentity securityIdentity;
+
+    @Mock
+    private Principal principal;
+
+    private UserProfileResource userProfileResource;
+
+    @BeforeEach
+    public void setup() {
+        userProfileResource = new UserProfileResource(userRepository, v1Mappers);
+    }
+
+    @Test
+    public void testGetUserProfileSuccess() {
+        when(securityIdentity.getPrincipal()).thenReturn(principal);
+        when(principal.getName()).thenReturn("testuser");
+
+        User user = new User();
+        user.firstname = "John";
+        user.lastname = "Doe";
+        user.username = "testuser";
+        user.organizations = java.util.List.of();
+
+        when(userRepository.findByUsername("testuser")).thenReturn(user);
+
+        Response response = userProfileResource.getUserOrganizations(securityIdentity);
+        assertEquals(200, response.getStatus());
+
+        UserProfileDTO dto = (UserProfileDTO) response.getEntity();
+        assertEquals("John", dto.firstname());
+        assertEquals("Doe", dto.lastname());
+    }
+
+    @Test
+    public void testGetUserProfileNotFound() {
+        when(securityIdentity.getPrincipal()).thenReturn(principal);
+        when(principal.getName()).thenReturn("testuser");
+
+        when(userRepository.findByUsername("testuser")).thenReturn(null);
+
+        Response response = userProfileResource.getUserOrganizations(securityIdentity);
+        assertEquals(404, response.getStatus());
+    }
+
+    @Test
+    public void testSetDefaultOrganizationNotFound() {
+        when(securityIdentity.getPrincipal()).thenReturn(principal);
+        when(principal.getName()).thenReturn("testuser");
+
+        when(userRepository.findByUsername("testuser")).thenReturn(null);
+
+        Response response = userProfileResource.setDefaultOrganization(securityIdentity, "org-1");
+        assertEquals(404, response.getStatus());
+    }
+}

--- a/control-plane/src/test/java/io/reshapr/ctrl/service/ExpositionDiscoveryServiceHandlerTest.java
+++ b/control-plane/src/test/java/io/reshapr/ctrl/service/ExpositionDiscoveryServiceHandlerTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright The Reshapr Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.reshapr.ctrl.service;
+
+import io.reshapr.ctrl.model.Exposition;
+import io.reshapr.ctrl.model.GatewayGroup;
+import io.reshapr.ctrl.model.ConfigurationPlan;
+import io.reshapr.ctrl.model.Service;
+import io.reshapr.ctrl.model.ServiceType;
+import io.reshapr.ctrl.repository.ArtifactRepository;
+import io.reshapr.discovery.exposition.v1.ExpositionDiscoveryRequest;
+import io.reshapr.discovery.exposition.v1.ExpositionDiscoveryResponse;
+import io.grpc.stub.StreamObserver;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+/**
+ * @author vaishnav
+ */
+@ExtendWith(MockitoExtension.class)
+public class ExpositionDiscoveryServiceHandlerTest {
+
+    @Mock
+    private ExpositionManagerService expositionManagerService;
+
+    @Mock
+    private ArtifactRepository artifactRepository;
+
+    @Mock
+    private StreamObserver<ExpositionDiscoveryResponse> responseObserver;
+
+    private ExpositionDiscoveryServiceHandler handler;
+
+    @BeforeEach
+    public void setup() {
+        handler = new ExpositionDiscoveryServiceHandler(expositionManagerService, artifactRepository);
+    }
+
+    @Test
+    public void testDiscoverExpositions() throws Exception {
+        ExpositionDiscoveryRequest request = ExpositionDiscoveryRequest.newBuilder()
+                .setGatewayId("gw-1")
+                .build();
+
+        Exposition exposition = new Exposition();
+        exposition.id = "exp-1";
+        
+        GatewayGroup group = new GatewayGroup();
+        group.name = "group-1";
+        exposition.gatewayGroup = group;
+        
+        ConfigurationPlan plan = new ConfigurationPlan();
+        plan.id = "plan-1";
+        plan.name = "plan-1";
+        plan.backendEndpoint = "http://backend";
+        
+        Service service = new Service();
+        service.id = "srv-1";
+        service.name = "srv";
+        service.version = "1.0";
+        service.organizationId = "org-1";
+        service.type = ServiceType.REST;
+        plan.service = service;
+        exposition.service = service;
+        
+        exposition.configurationPlan = plan;
+
+        when(expositionManagerService.getGatewayExpositions(eq("gw-1"), any(), any(), nullable(String.class)))
+                .thenReturn(List.of(exposition));
+
+        handler.discoverExpositions(request, responseObserver);
+
+        ArgumentCaptor<ExpositionDiscoveryResponse> captor = ArgumentCaptor.forClass(ExpositionDiscoveryResponse.class);
+        verify(responseObserver, times(1)).onNext(captor.capture());
+        verify(responseObserver, times(1)).onCompleted();
+
+        ExpositionDiscoveryResponse response = captor.getValue();
+        assertEquals(1, response.getExpositionsCount());
+        assertEquals("exp-1", response.getExpositions(0).getId());
+    }
+}

--- a/control-plane/src/test/java/io/reshapr/ctrl/service/ExpositionManagerServiceTest.java
+++ b/control-plane/src/test/java/io/reshapr/ctrl/service/ExpositionManagerServiceTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright The Reshapr Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.reshapr.ctrl.service;
+
+import io.reshapr.ctrl.model.ConfigurationPlan;
+import io.reshapr.ctrl.model.Exposition;
+import io.reshapr.ctrl.model.GatewayGroup;
+import io.reshapr.ctrl.model.Service;
+import io.reshapr.ctrl.repository.ActiveExpositionRepository;
+import io.reshapr.ctrl.repository.ConfigurationPlanRepository;
+import io.reshapr.ctrl.repository.ExpositionRepository;
+import io.reshapr.ctrl.repository.GatewayGroupRepository;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+/**
+ * @author vaishnav
+ */
+@ExtendWith(MockitoExtension.class)
+public class ExpositionManagerServiceTest {
+
+    @Mock
+    private ExpositionRepository expositionRepository;
+
+    @Mock
+    private ConfigurationPlanRepository configurationPlanRepository;
+
+    @Mock
+    private GatewayGroupManagerService gatewayGroupManagerService;
+
+    @Mock
+    private ActiveExpositionRepository activeExpositionRepository;
+
+    @Mock
+    private GatewayManagerService gatewayManagerService;
+
+    @Mock
+    private GatewayGroupRepository gatewayGroupRepository;
+
+    @Mock
+    private ClusterEventBroadcaster clusterEventBroadcaster;
+
+    @InjectMocks
+    private ExpositionManagerService expositionManagerService;
+
+    private ConfigurationPlan configurationPlan;
+    private GatewayGroup gatewayGroup;
+
+    @BeforeEach
+    public void setup() {
+        Service service = new Service();
+        service.name = "test-svc";
+        service.version = "1.0.0";
+
+        configurationPlan = new ConfigurationPlan();
+        configurationPlan.id = "plan-1";
+        configurationPlan.name = "default-plan";
+        configurationPlan.service = service;
+
+        gatewayGroup = new GatewayGroup();
+        gatewayGroup.id = "group-1";
+        gatewayGroup.name = "internal-gateways";
+    }
+
+    @Test
+    public void testExposeConfigurationSuccess() throws DependencyNotFoundException {
+        when(configurationPlanRepository.findById("plan-1")).thenReturn(configurationPlan);
+        when(gatewayGroupManagerService.getAvailableGatewayGroups()).thenReturn(List.of(gatewayGroup));
+        doNothing().when(expositionRepository).persistAndFlush(any(Exposition.class));
+
+        Exposition result = expositionManagerService.exposeConfiguration("plan-1", "group-1", "custom-name");
+
+        assertNotNull(result);
+        assertEquals("custom-name", result.name);
+        assertEquals("plan-1", result.configurationPlan.id);
+        assertEquals("group-1", result.gatewayGroup.id);
+        verify(clusterEventBroadcaster, times(1)).publishExpositionCreationEvent(any(Exposition.class), eq(gatewayGroup));
+    }
+
+    @Test
+    public void testExposeConfigurationPlanNotFound() {
+        when(configurationPlanRepository.findById("plan-1")).thenReturn(null);
+
+        assertThrows(DependencyNotFoundException.class, () -> {
+            expositionManagerService.exposeConfiguration("plan-1", "group-1", "custom-name");
+        });
+    }
+
+    @Test
+    public void testExposeConfigurationGatewayGroupNotFound() {
+        when(configurationPlanRepository.findById("plan-1")).thenReturn(configurationPlan);
+        when(gatewayGroupManagerService.getAvailableGatewayGroups()).thenReturn(List.of());
+
+        assertThrows(DependencyNotFoundException.class, () -> {
+            expositionManagerService.exposeConfiguration("plan-1", "group-1", "custom-name");
+        });
+    }
+
+    @Test
+    public void testSuggestExpositionNameUnique() {
+        when(expositionRepository.findByName("test-svc-1-0-0-default-plan")).thenReturn(null);
+        String name = expositionManagerService.suggestExpositionName(configurationPlan.service, configurationPlan);
+        assertEquals("test-svc-1-0-0-default-plan", name);
+    }
+
+    @Test
+    public void testSuggestExpositionNameCollision() {
+        when(expositionRepository.findByName("test-svc-1-0-0-default-plan")).thenReturn(new Exposition());
+        when(expositionRepository.findByName("test-svc-1-0-0-default-plan-2")).thenReturn(null);
+
+        String name = expositionManagerService.suggestExpositionName(configurationPlan.service, configurationPlan);
+        assertEquals("test-svc-1-0-0-default-plan-2", name);
+    }
+}

--- a/control-plane/src/test/java/io/reshapr/ctrl/service/GatewayGroupManagerServiceTest.java
+++ b/control-plane/src/test/java/io/reshapr/ctrl/service/GatewayGroupManagerServiceTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright The Reshapr Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.reshapr.ctrl.service;
+
+import io.reshapr.ctrl.model.GatewayGroup;
+import io.reshapr.ctrl.model.SharedResource;
+import io.reshapr.ctrl.model.SharedResourceTypes;
+import io.reshapr.ctrl.repository.GatewayGroupRepository;
+import io.reshapr.ctrl.security.ReshaprTenantResolver;
+
+import io.quarkus.hibernate.orm.panache.PanacheQuery;
+import io.vertx.mutiny.core.Context;
+import io.vertx.mutiny.core.Vertx;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+/**
+ * @author vaishnav
+ */
+@ExtendWith(MockitoExtension.class)
+public class GatewayGroupManagerServiceTest {
+
+    @Mock
+    private GatewayGroupRepository gatewayGroupRepository;
+
+    @Mock
+    private Context vertxContext;
+
+    @Mock
+    private PanacheQuery<GatewayGroup> panacheQuery;
+
+    private GatewayGroupManagerService gatewayGroupManagerService;
+
+    private MockedStatic<Vertx> mockedVertx;
+    private MockedStatic<SharedResource> mockedSharedResource;
+
+    @BeforeEach
+    public void setup() {
+        gatewayGroupManagerService = new GatewayGroupManagerService(gatewayGroupRepository);
+        mockedVertx = mockStatic(Vertx.class);
+        mockedSharedResource = mockStatic(SharedResource.class);
+    }
+
+    @AfterEach
+    public void teardown() {
+        mockedVertx.close();
+        mockedSharedResource.close();
+    }
+
+    @Test
+    public void testGetOwnedGatewayGroups() {
+        when(Vertx.currentContext()).thenReturn(vertxContext);
+        when(vertxContext.getLocal(ReshaprTenantResolver.TENANT_ID_CONTEXT_KEY)).thenReturn("org-1");
+
+        GatewayGroup group = new GatewayGroup();
+        group.id = "gg-1";
+        
+        when(gatewayGroupRepository.find("organizationId", "org-1")).thenReturn(panacheQuery);
+        when(panacheQuery.list()).thenReturn(List.of(group));
+
+        List<GatewayGroup> result = gatewayGroupManagerService.getOwnedGatewayGroups();
+        assertEquals(1, result.size());
+        assertEquals("gg-1", result.get(0).id);
+    }
+
+    @Test
+    public void testGetAvailableGatewayGroups() {
+        when(Vertx.currentContext()).thenReturn(vertxContext);
+        when(vertxContext.getLocal(ReshaprTenantResolver.TENANT_ID_CONTEXT_KEY)).thenReturn("org-1");
+
+        SharedResource resource = new SharedResource();
+        resource.resourceIds = List.of("gg-2", "gg-3");
+
+        mockedSharedResource.when(() -> SharedResource.findByTypeAndOrganizationId(SharedResourceTypes.GATEWAY_GROUP, "org-1"))
+                .thenReturn(List.of(resource));
+
+        GatewayGroup group = new GatewayGroup();
+        group.id = "gg-1"; // Assuming it finds owned + shared.
+        
+        when(gatewayGroupRepository.findOwnedAndWithIds("org-1", List.of("gg-2", "gg-3")))
+                .thenReturn(List.of(group));
+
+        List<GatewayGroup> result = gatewayGroupManagerService.getAvailableGatewayGroups();
+        assertEquals(1, result.size());
+        assertEquals("gg-1", result.get(0).id);
+    }
+}

--- a/control-plane/src/test/java/io/reshapr/ctrl/service/OffboardingServiceTest.java
+++ b/control-plane/src/test/java/io/reshapr/ctrl/service/OffboardingServiceTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright The Reshapr Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.reshapr.ctrl.service;
+
+import io.reshapr.ctrl.model.Organization;
+import io.reshapr.ctrl.model.User;
+import io.reshapr.ctrl.repository.ApiTokenRepository;
+import io.reshapr.ctrl.repository.GatewayGroupRepository;
+import io.reshapr.ctrl.repository.GatewayRepository;
+import io.reshapr.ctrl.repository.OrganizationRepository;
+import io.reshapr.ctrl.repository.QuotaRepository;
+import io.reshapr.ctrl.repository.SecretRepository;
+import io.reshapr.ctrl.repository.ServiceRepository;
+import io.reshapr.ctrl.repository.UserRepository;
+import io.reshapr.ctrl.security.ReshaprTenantContext;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.ArrayList;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+/**
+ * @author vaishnav
+ */
+@ExtendWith(MockitoExtension.class)
+public class OffboardingServiceTest {
+
+    @Mock
+    private OrganizationRepository organizationRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private ServiceRepository serviceRepository;
+
+    @Mock
+    private ServiceManagerService serviceManagerService;
+
+    @Mock
+    private SecretRepository secretRepository;
+
+    @Mock
+    private GatewayRepository gatewayRepository;
+
+    @Mock
+    private GatewayGroupRepository gatewayGroupRepository;
+
+    @Mock
+    private QuotaRepository quotaRepository;
+
+    @Mock
+    private ApiTokenRepository apiTokenRepository;
+
+    private OffboardingService offboardingService;
+    private MockedStatic<ReshaprTenantContext> mockedContext;
+
+    @BeforeEach
+    public void setup() {
+        offboardingService = new OffboardingService(
+                organizationRepository, userRepository, serviceRepository,
+                serviceManagerService, secretRepository, gatewayRepository,
+                gatewayGroupRepository, quotaRepository, apiTokenRepository
+        );
+        mockedContext = mockStatic(ReshaprTenantContext.class);
+    }
+
+    @AfterEach
+    public void teardown() {
+        mockedContext.close();
+    }
+
+    @Test
+    public void testDeleteOrganizationCannotDeleteRoot() {
+        assertThrows(IllegalStateException.class, () -> offboardingService.deleteOrganization("reshapr"));
+    }
+
+    @Test
+    public void testDeleteOrganizationNotFound() {
+        when(organizationRepository.findByName("org-1")).thenReturn(null);
+        assertThrows(DependencyNotFoundException.class, () -> offboardingService.deleteOrganization("org-1"));
+    }
+
+    @Test
+    public void testDeleteUserNotFound() {
+        when(userRepository.findByUsername("user-1")).thenReturn(null);
+        assertThrows(DependencyNotFoundException.class, () -> offboardingService.deleteUser("user-1"));
+    }
+
+    @Test
+    public void testDeleteUserCannotDeleteRootOwner() {
+        User user = new User();
+        user.username = "root-owner";
+
+        Organization rootOrg = new Organization();
+        rootOrg.owner = user;
+
+        when(userRepository.findByUsername("root-owner")).thenReturn(user);
+        when(organizationRepository.findByName("reshapr")).thenReturn(rootOrg);
+
+        assertThrows(IllegalStateException.class, () -> offboardingService.deleteUser("root-owner"));
+    }
+}

--- a/control-plane/src/test/java/io/reshapr/ctrl/service/OnboardingServiceTest.java
+++ b/control-plane/src/test/java/io/reshapr/ctrl/service/OnboardingServiceTest.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright The Reshapr Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.reshapr.ctrl.service;
+
+import io.reshapr.ctrl.model.Organization;
+import io.reshapr.ctrl.model.User;
+import io.reshapr.ctrl.model.UserStatus;
+import io.reshapr.ctrl.repository.OrganizationRepository;
+import io.reshapr.ctrl.repository.QuotaRepository;
+import io.reshapr.ctrl.repository.UserRepository;
+import io.reshapr.ctrl.service.OnboardingService.OrganizationInfo;
+import io.reshapr.ctrl.service.OnboardingService.UserInfo;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.ArrayList;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+/**
+ * @author vaishnav
+ */
+@ExtendWith(MockitoExtension.class)
+public class OnboardingServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private OrganizationRepository organizationRepository;
+
+    @Mock
+    private QuotaRepository quotaRepository;
+
+    private OnboardingService onboardingService;
+
+    @BeforeEach
+    public void setup() {
+        onboardingService = new OnboardingService(userRepository, organizationRepository, quotaRepository);
+    }
+
+    @Test
+    public void testCreateUserSuccess() throws Exception {
+        UserInfo userInfo = new UserInfo("jdoe", "jdoe@example.com", "password", "John", "Doe");
+        when(userRepository.findByUsername("jdoe")).thenReturn(null);
+
+        User user = onboardingService.createUser(userInfo);
+
+        assertNotNull(user);
+        assertEquals("jdoe", user.username);
+        assertEquals("jdoe@example.com", user.email);
+        assertNotNull(user.password);
+        assertEquals("John", user.firstname);
+        assertEquals("Doe", user.lastname);
+        assertEquals(UserStatus.REGISTERED, user.status);
+
+        verify(userRepository, times(1)).persistAndFlush(user);
+    }
+
+    @Test
+    public void testCreateUserAlreadyExists() {
+        UserInfo userInfo = new UserInfo("jdoe", "jdoe@example.com", "password", "John", "Doe");
+        User existingUser = new User();
+        when(userRepository.findByUsername("jdoe")).thenReturn(existingUser);
+
+        assertThrows(EntityAlreadyExistException.class, () -> onboardingService.createUser(userInfo));
+        verify(userRepository, never()).persistAndFlush(any());
+    }
+
+    @Test
+    public void testCreateUserAndAttachToOrganizationSuccess() throws Exception {
+        UserInfo userInfo = new UserInfo("jdoe", "jdoe@example.com", "password", "John", "Doe");
+        Organization org = new Organization();
+        org.name = "org-1";
+
+        when(organizationRepository.findByName("org-1")).thenReturn(org);
+        when(userRepository.findByUsername("jdoe")).thenReturn(null);
+
+        User user = onboardingService.createUserAndAttachToOrganization(userInfo, "org-1");
+
+        assertNotNull(user);
+        assertEquals(1, user.organizations.size());
+        assertEquals(org, user.organizations.get(0));
+        assertEquals(org, user.defaultOrganization);
+
+        verify(userRepository, times(2)).persistAndFlush(user); // Once for create, once for attach
+    }
+
+    @Test
+    public void testCreateOrganizationSuccess() throws Exception {
+        OrganizationInfo orgInfo = new OrganizationInfo("org-1", "Description", "icon-url");
+        User user = new User();
+        user.username = "jdoe";
+
+        when(userRepository.findByUsername("jdoe")).thenReturn(user);
+        when(organizationRepository.findByName("org-1")).thenReturn(null);
+
+        Organization org = onboardingService.createOrganization("jdoe", orgInfo);
+
+        assertNotNull(org);
+        assertEquals("org-1", org.name);
+        assertEquals("Description", org.description);
+        assertEquals("icon-url", org.icon);
+        assertEquals(user, org.owner);
+
+        verify(organizationRepository, times(1)).persistAndFlush(org);
+        assertEquals(1, user.organizations.size());
+        assertEquals(org, user.defaultOrganization);
+        verify(userRepository, times(1)).persistAndFlush(user);
+    }
+
+    @Test
+    public void testCreateOrganizationAlreadyExists() {
+        OrganizationInfo orgInfo = new OrganizationInfo("org-1", "Description", "icon-url");
+        User user = new User();
+        
+        when(userRepository.findByUsername("jdoe")).thenReturn(user);
+        when(organizationRepository.findByName("org-1")).thenReturn(new Organization());
+
+        assertThrows(EntityAlreadyExistException.class, () -> onboardingService.createOrganization("jdoe", orgInfo));
+    }
+
+    @Test
+    public void testCreateOrganizationUserNotFound() {
+        OrganizationInfo orgInfo = new OrganizationInfo("org-1", "Description", "icon-url");
+        when(userRepository.findByUsername("jdoe")).thenReturn(null);
+
+        assertThrows(DependencyNotFoundException.class, () -> onboardingService.createOrganization("jdoe", orgInfo));
+    }
+}

--- a/control-plane/src/test/java/io/reshapr/ctrl/service/TokenManagerServiceTest.java
+++ b/control-plane/src/test/java/io/reshapr/ctrl/service/TokenManagerServiceTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright The Reshapr Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.reshapr.ctrl.service;
+
+import io.reshapr.ctrl.model.ApiToken;
+import io.reshapr.ctrl.model.User;
+import io.reshapr.ctrl.repository.ApiTokenRepository;
+import io.reshapr.ctrl.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * @author vaishnav
+ */
+@ExtendWith(MockitoExtension.class)
+public class TokenManagerServiceTest {
+
+    @Mock
+    private ApiTokenRepository apiTokenRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    private TokenManagerService tokenManagerService;
+
+    @BeforeEach
+    public void setup() {
+        tokenManagerService = new TokenManagerService(apiTokenRepository, userRepository);
+    }
+
+    @Test
+    public void testGetApiTokens() {
+        ApiToken token = new ApiToken();
+        when(apiTokenRepository.findByOrganizationId("org-1")).thenReturn(List.of(token));
+
+        List<ApiToken> result = tokenManagerService.getApiTokens("org-1");
+        assertEquals(1, result.size());
+    }
+
+    @Test
+    public void testGenerateApiTokenSuccess() throws Exception {
+        User user = new User();
+        user.username = "testuser";
+        when(userRepository.findByUsername("testuser")).thenReturn(user);
+
+        ApiToken token = tokenManagerService.generateApiToken("My Token", "org-1", 30, "testuser");
+        
+        assertNotNull(token);
+        assertEquals("My Token", token.name);
+        assertEquals("org-1", token.organizationId);
+        assertEquals(user, token.user);
+        assertNotNull(token.token);
+        assertNotNull(token.validUntil);
+
+        verify(apiTokenRepository, times(1)).persist(token);
+    }
+
+    @Test
+    public void testGenerateApiTokenUserNotFound() {
+        when(userRepository.findByUsername("testuser")).thenReturn(null);
+
+        assertThrows(DependencyNotFoundException.class, () -> {
+            tokenManagerService.generateApiToken("My Token", "org-1", 30, "testuser");
+        });
+    }
+
+    @Test
+    public void testRevokeApiToken() {
+        ApiToken token = new ApiToken();
+        tokenManagerService.revokeApiToken(token);
+        verify(apiTokenRepository, times(1)).delete(token);
+    }
+}

--- a/control-plane/src/test/resources/io/reshapr/ctrl/artifacts/openapi.json
+++ b/control-plane/src/test/resources/io/reshapr/ctrl/artifacts/openapi.json
@@ -1,0 +1,22 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "My API",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/pets": {
+      "get": {
+        "operationId": "getPets"
+      },
+      "post": {
+        "operationId": "createPet"
+      }
+    },
+    "/pets/{petId}": {
+      "get": {
+        "operationId": "getPetById"
+      }
+    }
+  }
+}

--- a/control-plane/src/test/resources/io/reshapr/ctrl/artifacts/schema.graphql
+++ b/control-plane/src/test/resources/io/reshapr/ctrl/artifacts/schema.graphql
@@ -1,0 +1,14 @@
+type Query {
+  books: [Book]
+  book(id: ID!): Book
+}
+
+type Mutation {
+  addBook(title: String!, author: String!): Book
+}
+
+type Book {
+  id: ID!
+  title: String!
+  author: String!
+}

--- a/e2e-tests/pom.xml
+++ b/e2e-tests/pom.xml
@@ -53,6 +53,19 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>report-aggregate</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>report-aggregate</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/e2e-tests/pom.xml
+++ b/e2e-tests/pom.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>reshapr-e2e-tests</artifactId>
+  <parent>
+    <groupId>io.reshapr</groupId>
+    <artifactId>reshapr-parent</artifactId>
+    <version>0.2.4-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <name>Reshapr E2E Tests</name>
+  <description>End-to-End tests spanning Control Plane and Proxy</description>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.reshapr</groupId>
+      <artifactId>reshapr-ctrl</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.reshapr</groupId>
+      <artifactId>reshapr</artifactId> <!-- proxy module -->
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-junit5</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.rest-assured</groupId>
+      <artifactId>rest-assured</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <version>${surefire-plugin.version}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/e2e-tests/src/test/java/io/reshapr/e2e/ReshaprE2ETest.java
+++ b/e2e-tests/src/test/java/io/reshapr/e2e/ReshaprE2ETest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright The Reshapr Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.reshapr.e2e;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Placeholder for End-to-End Tests.
+ * In a real scenario, this would spin up both the control-plane and the proxy,
+ * configure the control-plane, and route traffic through the proxy.
+ *
+ * @author vaishnav
+ */
+public class ReshaprE2ETest {
+
+    @Test
+    public void testFullSystemFlow() {
+        // E2E infrastructure setup placeholder
+        assertTrue(true, "E2E tests infrastructure initialized");
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,7 @@
                     <limit>
                       <counter>INSTRUCTION</counter>
                       <value>COVEREDRATIO</value>
-                      <minimum>0.70</minimum>
+                      <minimum>0.28</minimum>
                     </limit>
                   </limits>
                 </rule>

--- a/pom.xml
+++ b/pom.xml
@@ -12,6 +12,7 @@
     <module>commons</module>
     <module>control-plane</module>
     <module>proxy</module>
+    <module>e2e-tests</module>
   </modules>
 
   <name>Reshapr</name>
@@ -66,6 +67,52 @@
       </dependency>
     </dependencies>
   </dependencyManagement>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <version>0.8.15</version>
+        <executions>
+          <execution>
+            <id>prepare-agent</id>
+            <goals>
+              <goal>prepare-agent</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>report</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>report</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>check</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>check</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <rule>
+                  <element>BUNDLE</element>
+                  <limits>
+                    <limit>
+                      <counter>INSTRUCTION</counter>
+                      <value>COVEREDRATIO</value>
+                      <minimum>0.70</minimum>
+                    </limit>
+                  </limits>
+                </rule>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 
   <profiles>
     <profile>

--- a/proxy/src/test/java/io/reshapr/proxy/proxy/ProxyServiceIT.java
+++ b/proxy/src/test/java/io/reshapr/proxy/proxy/ProxyServiceIT.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright The Reshapr Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.reshapr.proxy.proxy;
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+import io.restassured.http.ContentType;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.containsString;
+
+/**
+ * @author vaishnav
+ */
+@QuarkusIntegrationTest
+public class ProxyServiceIT {
+
+    // The default API key or we can just expect 401/404 for unconfigured endpoints
+    private static final String DEFAULT_API_KEY = "CzBuQ9B0i8qrUQe6WLiDLqR3gv4iCbxvjTJQP0z0CFGQbjgBHPZSusa9d1gZKwwjdoCsJ8ogRwRzc06GipJSjSDkFOy0BSOKvAa2EjU3As9I5UjgizTzxsJAVJIXtdo2xiXHhcry9KeJa0zRhDtGmm8WMujoXrlfj0ChlJKaHZiZsRthd4UHrWkKur9KySXpPFP21H4C0Cq6OgM1rJpvMZ7Jd2ZzeEcd5lKE4PlchHZBVEdu8jYzjQtU50fkOPoR";
+
+    @Test
+    public void testUnknownExpositionReturns404() {
+        // Hitting the MCP endpoint with an unknown exposition ID
+        given()
+            .header("Authorization", "Bearer " + DEFAULT_API_KEY)
+            .contentType(ContentType.JSON)
+            .body("""
+                {
+                    "jsonrpc": "2.0",
+                    "method": "server/discover",
+                    "id": 1
+                }
+                """)
+        .when()
+            .post("/mcp/unknown-exposition-id")
+        .then()
+            .statusCode(404)
+            .body(containsString("not found"));
+    }
+
+    @Test
+    public void testUnknownOrganizationExpositionReturns404() {
+        given()
+            .header("Authorization", "Bearer " + DEFAULT_API_KEY)
+            .contentType(ContentType.JSON)
+            .body("""
+                {
+                    "jsonrpc": "2.0",
+                    "method": "server/discover",
+                    "id": 2
+                }
+                """)
+        .when()
+            .post("/mcp/unknown-org/unknown-exposition")
+        .then()
+            .statusCode(404)
+            .body(containsString("not found"));
+    }
+}


### PR DESCRIPTION
This PR is the first step toward improving test coverage across the reShapr codebase, focusing on the **control-plane**.

### Coverage

The current control-plane coverage is:

- **Instruction coverage:** 29%
- **Branch coverage:** 24%
- **Line coverage:** ~30%

Tests have been added/improved based on coverage and complexity, with further improvements planned through iterative PRs.

### CI

- Update `build-verify.yml` to check test coverage during CI.
- Ensure coverage does not regress as new changes are merged.

This is an incremental step toward the overall **70% coverage target** for the reShapr codebase.