### PR TITLE
feat: Add OAuth2 Audience Validation support to CLI and Web UI

### DIFF
--- a/cli/src/commands/config.ts
+++ b/cli/src/commands/config.ts
@@ -111,6 +111,13 @@ configCommand.command('get <id>')
       if (config.oauth2Configuration.scopes) {
         Logger.log(`  Scopes               : ${config.oauth2Configuration.scopes.join(', ')}`);
       }
+      if (config.oauth2Configuration.disableAudienceValidation) {
+        Logger.log(`  Disable Audience Val.: Yes`);
+      } else {
+        if (config.oauth2Configuration.staticAudiences) {
+          Logger.log(`  Static Audiences     : ${config.oauth2Configuration.staticAudiences.join(', ')}`);
+        }
+      }
     } else {
       Logger.log(`OAuth2          : No`);
     }
@@ -211,6 +218,8 @@ configCommand.command('create-oauth <name>')
   .requiredOption('--oas, --oauth2AuthorizationServers [<authorizationServer1>, <authorizationServer2>]', 'A list of OAuth2 authorization server URLs to accept tokens from')
   .requiredOption('--oju, --oauth2jwksUri <jwksUri>', 'The JWKS URI to validate OAuth2 tokens')
   .option('--osc, --oauth2Scopes [<scope1>, <scope2>]', 'A list of OAuth2 scopes to enforce presence in the access token')
+  .option('--odav, --oauth2DisableAudienceValidation', 'Disable audience validation for OAuth2 tokens')
+  .option('--osa, --oauth2StaticAudiences [<audience1>, <audience2>]', 'A list of static audiences to validate against (JSON array)')
   .option('--audit', 'Enable audit logging for this configuration plan')
   .option('--ct, --cacheTtl <cacheTtlMs>', 'Cache TTL in milliseconds', '30000')
   .option('--cs, --cacheScope <cacheScope>', 'Cache scope (e.g. public, private)', 'public')
@@ -226,7 +235,9 @@ configCommand.command('create-oauth <name>')
     options.oauth2Configuration = {
       authorizationServers: getArrayOfStrings(options.oauth2AuthorizationServers, 'oauth2AuthorizationServers'),
       jwksUri: options.oauth2jwksUri,
-      scopes: options.oauth2Scopes ? getArrayOfStrings(options.oauth2Scopes, 'oauth2Scopes') : undefined
+      scopes: options.oauth2Scopes ? getArrayOfStrings(options.oauth2Scopes, 'oauth2Scopes') : undefined,
+      disableAudienceValidation: options.oauth2DisableAudienceValidation || false,
+      staticAudiences: options.oauth2StaticAudiences ? getArrayOfStrings(options.oauth2StaticAudiences, 'oauth2StaticAudiences') : undefined
     };
     
     const response = await fetch(`${ConfigUtil.config.server}/api/v1/configurationPlans`, {

--- a/control-plane/src/main/java/io/reshapr/ctrl/rest/v1/SecretResource.java
+++ b/control-plane/src/main/java/io/reshapr/ctrl/rest/v1/SecretResource.java
@@ -51,12 +51,10 @@ public class SecretResource {
 
    private final SecretRepository secretRepository;
    private final Mappers v1Mappers;
-   private final MappersImpl mappersImpl;
 
-   public SecretResource(SecretRepository secretRepository, Mappers v1Mappers, MappersImpl mappersImpl) {
+   public SecretResource(SecretRepository secretRepository, Mappers v1Mappers) {
       this.secretRepository = secretRepository;
       this.v1Mappers = v1Mappers;
-      this.mappersImpl = mappersImpl;
    }
 
    @GET

--- a/web-ui/src/lib/components/artifacts/QuickStartWizard.svelte
+++ b/web-ui/src/lib/components/artifacts/QuickStartWizard.svelte
@@ -98,6 +98,8 @@
 	let oauthAuthServersText = $state('');
 	let oauthJwksUri = $state('');
 	let oauthScopesText = $state('');
+	let oauthDisableAudienceVal = $state(false);
+	let oauthStaticAudiencesText = $state('');
 
 	// Finish step.
 	let planId = $state('');
@@ -139,6 +141,8 @@
 		oauthAuthServersText = '';
 		oauthJwksUri = '';
 		oauthScopesText = '';
+		oauthDisableAudienceVal = false;
+		oauthStaticAudiencesText = '';
 		planId = '';
 		planExisted = false;
 		createdKey = null;
@@ -200,7 +204,9 @@
 			body.oauth2Configuration = {
 				authorizationServers: parseOperationsList(oauthAuthServersText),
 				jwksUri: oauthJwksUri.trim() || null,
-				scopes: parseOperationsList(oauthScopesText)
+				scopes: parseOperationsList(oauthScopesText),
+				disableAudienceValidation: oauthDisableAudienceVal,
+				staticAudiences: parseOperationsList(oauthStaticAudiencesText)
 			};
 			delete body.apiKey;
 			return;
@@ -540,6 +546,29 @@
 											/>
 											<p class="text-muted-foreground text-xs">One scope per line.</p>
 										</div>
+										<div class="flex items-center justify-between gap-4 rounded-lg border p-4">
+											<div class="space-y-0.5">
+												<Label for="qs-oauth-disable-aud" class="text-sm font-medium">
+													Disable audience validation
+												</Label>
+												<p class="text-muted-foreground text-sm">
+													If enabled, bypasses validating the aud claim in OAuth tokens.
+												</p>
+											</div>
+											<Switch id="qs-oauth-disable-aud" checked={oauthDisableAudienceVal} onCheckedChange={(v) => (oauthDisableAudienceVal = v)} />
+										</div>
+										{#if !oauthDisableAudienceVal}
+											<div class="space-y-2">
+												<Label for="qs-oauth-static-aud">Static audiences</Label>
+												<Textarea
+													id="qs-oauth-static-aud"
+													bind:value={oauthStaticAudiencesText}
+													rows={2}
+													placeholder={'https://api.example.com'}
+												/>
+												<p class="text-muted-foreground text-xs">One audience per line.</p>
+											</div>
+										{/if}
 									{/if}
 								</div>
 							{/if}

--- a/web-ui/src/lib/components/plan/PlanEditor.svelte
+++ b/web-ui/src/lib/components/plan/PlanEditor.svelte
@@ -24,6 +24,7 @@
 	import { Checkbox } from '$lib/components/ui/checkbox/index.js';
 	import { Input } from '$lib/components/ui/input/index.js';
 	import { Label } from '$lib/components/ui/label/index.js';
+	import { Switch } from '$lib/components/ui/switch/index.js';
 	import { Textarea } from '$lib/components/ui/textarea/index.js';
 	import * as Select from '$lib/components/ui/select/index.js';
 	import { parseArtifactRefList, type ArtifactRef, type ArtifactType } from '$lib/artifacts/index.js';
@@ -97,6 +98,8 @@
 	let oauthAuthServersText = $state('');
 	let oauthJwksUri = $state('');
 	let oauthScopesText = $state('');
+	let oauthDisableAudienceVal = $state(false);
+	let oauthStaticAudiencesText = $state('');
 
 	// ── UI state ────────────────────────────────────────────────────────────────
 	let loading = $state(true);
@@ -325,6 +328,8 @@
 			oauthAuthServersText = formatOperationsList(oauth.authorizationServers);
 			oauthJwksUri = typeof oauth.jwksUri === 'string' ? oauth.jwksUri : '';
 			oauthScopesText = formatOperationsList(oauth.scopes);
+			oauthDisableAudienceVal = !!oauth.disableAudienceValidation;
+			oauthStaticAudiencesText = formatOperationsList(oauth.staticAudiences);
 		} else if (typeof plan.apiKey === 'string' && plan.apiKey.trim() !== '') {
 			mcpAuthMode = 'apikey';
 		} else {
@@ -437,7 +442,9 @@
 			body.oauth2Configuration = {
 				authorizationServers: parseOperationsList(oauthAuthServersText),
 				jwksUri: oauthJwksUri.trim() || null,
-				scopes: parseOperationsList(oauthScopesText)
+				scopes: parseOperationsList(oauthScopesText),
+				disableAudienceValidation: oauthDisableAudienceVal,
+				staticAudiences: parseOperationsList(oauthStaticAudiencesText)
 			};
 			delete body.apiKey;
 		} else {
@@ -926,6 +933,30 @@
 					/>
 					<p class="text-muted-foreground text-xs">One scope per line.</p>
 				</div>
+				<div class="flex items-center justify-between gap-4 rounded-lg border p-4">
+					<div class="space-y-0.5">
+						<Label for="oauthDisableAudienceVal" class="text-sm font-medium">
+							Disable audience validation
+						</Label>
+						<p class="text-muted-foreground text-sm">
+							If enabled, bypasses validating the aud claim in OAuth tokens.
+						</p>
+					</div>
+					<Switch id="oauthDisableAudienceVal" checked={oauthDisableAudienceVal} onCheckedChange={(v) => (oauthDisableAudienceVal = v)} disabled={loading} />
+				</div>
+				{#if !oauthDisableAudienceVal}
+					<div class="space-y-2">
+						<Label for="oauthStaticAudiences">Static audiences</Label>
+						<Textarea
+							id="oauthStaticAudiences"
+							bind:value={oauthStaticAudiencesText}
+							rows={3}
+							disabled={loading}
+							placeholder={'https://api.example.com'}
+						/>
+						<p class="text-muted-foreground text-xs">One audience per line.</p>
+					</div>
+				{/if}
 			{/if}
 		</Card.Content>
 		{/if}

--- a/web-ui/src/lib/components/plan/planView.ts
+++ b/web-ui/src/lib/components/plan/planView.ts
@@ -122,7 +122,7 @@ export function capabilityGroups(
 
 // ── MCP endpoint (client-facing) authentication ─────────────────────────────
 export type McpAuth =
-	| { kind: 'oauth'; servers: string[]; scopes: string[]; jwksUri: string | null }
+	| { kind: 'oauth'; servers: string[]; scopes: string[]; jwksUri: string | null; disableAudienceValidation: boolean; staticAudiences: string[] }
 	| { kind: 'apikey' }
 	| { kind: 'none' };
 
@@ -133,7 +133,9 @@ export function mcpAuthOf(plan: Record<string, unknown> | null): McpAuth {
 			kind: 'oauth',
 			servers: arrOf(oauth.authorizationServers).map(String),
 			scopes: arrOf(oauth.scopes).map(String),
-			jwksUri: strOf(oauth.jwksUri)
+			jwksUri: strOf(oauth.jwksUri),
+			disableAudienceValidation: !!oauth.disableAudienceValidation,
+			staticAudiences: arrOf(oauth.staticAudiences).map(String)
 		};
 	}
 	if (strOf(plan?.apiKey)) return { kind: 'apikey' };


### PR DESCRIPTION
It completed the OAuth2 Audience Validation feature by adding support for it in the CLI and Web UI, replicating the backend capabilities introduced in #397.
Fixes #388

### Changes
* **Web UI:** Added "Disable Audience Validation" toggle and "Static Audiences" input fields to the Configuration Plan Editor and QuickStart Wizard.
* **CLI:** Added `--oauth2DisableAudienceValidation` (`--odav`) and `--oauth2StaticAudiences` (`--osa`) flags to the `config create-oauth` command, along with updated output mappings.
* **Fix (Control Plane):** Removed a redundant and unsafe `MappersImpl` injection from `SecretResource.java` which was crashing the Quarkus dev server (`quarkus:dev`) with an `UnsatisfiedResolutionException`.

<img width="1611" height="379" alt="Screenshot from 2026-09-11 23-48-08" src="https://github.com/user-attachments/assets/4e31ca16-2bd8-4ce7-98de-d1d54693f0cc" />

```bash
$ reshapr config create-oauth test-plan \
  --serviceId "0RK6QXQSAZ767" \
  --backendEndpoint "http://localhost:8080" \
  --oauth2AuthorizationServers '["https://auth.example.com"]' \
  --oauth2jwksUri "https://auth.example.com/certs" \
  --oauth2DisableAudienceValidation \
  --oauth2StaticAudiences '["https://static.example.com"]' \
  -o json
  
{
  "id": "0RK6R05FEZ7FH",
  "organizationId": "reshapr",
  "name": "test-plan",
  "serviceId": "0RK6QXQSAZ767",
  "backendEndpoint": "http://localhost:8080",
  "includedArtifacts": [],
  "oauth2Configuration": {
    "authorizationServers": [
      "https://auth.example.com"
    ],
    "jwksUri": "https://auth.example.com/certs",
    "staticAudiences": [
      "https://static.example.com"
    ],
    "disableAudienceValidation": true
  },
  "audit": false,
  "cachePolicy": {
    "ttlMs": 30000,
    "cacheScope": "public"
  }
}
```